### PR TITLE
feat: basic dapp example with svelte-tezos

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,12 @@
 		"": {
 			"name": "svelte-tezos-example",
 			"version": "0.0.1",
+			"dependencies": {
+				"@esbuild-plugins/node-globals-polyfill": "^0.2.3",
+				"buffer": "^6.0.3",
+				"svelte-tezos": "^1.0.0",
+				"vite-compatible-readable-stream": "^3.6.1"
+			},
 			"devDependencies": {
 				"@sveltejs/adapter-auto": "^2.0.0",
 				"@sveltejs/kit": "^1.20.4",
@@ -33,17 +39,159 @@
 				"node": ">=0.10.0"
 			}
 		},
+		"node_modules/@airgap/beacon-blockchain-substrate": {
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/@airgap/beacon-blockchain-substrate/-/beacon-blockchain-substrate-4.0.4.tgz",
+			"integrity": "sha512-aKggXvGtm+k6CDXzjowN42xIjkK5Aj++PGEmKK4RBvGNhwcWhd4S/5B09zURbUVcstcav2LM6G41X0OaNX7BYA==",
+			"dependencies": {
+				"@airgap/beacon-types": "4.0.4",
+				"@airgap/beacon-ui": "4.0.4"
+			}
+		},
+		"node_modules/@airgap/beacon-blockchain-tezos": {
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/@airgap/beacon-blockchain-tezos/-/beacon-blockchain-tezos-4.0.4.tgz",
+			"integrity": "sha512-1JkrSwhvtWdimAk3og48SMmw6BLa1lArtAwwiBJXszZeleQ3/35GPH0t2iJRkbx6xKRv/36zGi7muUaQ3Pgq1A==",
+			"dependencies": {
+				"@airgap/beacon-types": "4.0.4",
+				"@airgap/beacon-ui": "4.0.4"
+			}
+		},
+		"node_modules/@airgap/beacon-core": {
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/@airgap/beacon-core/-/beacon-core-4.0.4.tgz",
+			"integrity": "sha512-A64Q894XrivcfHgYD+iUz4Q9ymRnTLHcj3OIuW69lKk7eoJBi0PgFSpNNdENRQ6FXjLc0LNSbh8U+hG1MkNvgA==",
+			"dependencies": {
+				"@airgap/beacon-types": "4.0.4",
+				"@airgap/beacon-utils": "4.0.4",
+				"@stablelib/ed25519": "^1.0.3",
+				"@stablelib/nacl": "^1.0.4",
+				"@stablelib/utf8": "^1.0.1",
+				"@stablelib/x25519-session": "^1.0.4",
+				"bs58check": "2.1.2"
+			}
+		},
+		"node_modules/@airgap/beacon-dapp": {
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/@airgap/beacon-dapp/-/beacon-dapp-4.0.4.tgz",
+			"integrity": "sha512-b1GoYpbmFdE74OGtKhns4LzuPlnid1USCSRRjIGfLqzHoSF8WpoGegSVpVy3zK4+UMkR6Xv7p2hpYeH8aAqadg==",
+			"dependencies": {
+				"@airgap/beacon-core": "4.0.4",
+				"@airgap/beacon-transport-matrix": "4.0.4",
+				"@airgap/beacon-transport-postmessage": "4.0.4",
+				"@airgap/beacon-transport-walletconnect": "4.0.4",
+				"@airgap/beacon-ui": "4.0.4"
+			}
+		},
+		"node_modules/@airgap/beacon-sdk": {
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/@airgap/beacon-sdk/-/beacon-sdk-4.0.4.tgz",
+			"integrity": "sha512-jM3e8PJW4NDfExTqrUkCoZEeJxEV5926AVHJXjloWhTTAxtDqp/jgX408H6ygl12E23kmQ3JJqh7MWfa/Ku1MA==",
+			"dependencies": {
+				"@airgap/beacon-blockchain-substrate": "4.0.4",
+				"@airgap/beacon-blockchain-tezos": "4.0.4",
+				"@airgap/beacon-core": "4.0.4",
+				"@airgap/beacon-dapp": "4.0.4",
+				"@airgap/beacon-transport-matrix": "4.0.4",
+				"@airgap/beacon-transport-postmessage": "4.0.4",
+				"@airgap/beacon-types": "4.0.4",
+				"@airgap/beacon-ui": "4.0.4",
+				"@airgap/beacon-utils": "4.0.4",
+				"@airgap/beacon-wallet": "4.0.4"
+			}
+		},
+		"node_modules/@airgap/beacon-transport-matrix": {
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/@airgap/beacon-transport-matrix/-/beacon-transport-matrix-4.0.4.tgz",
+			"integrity": "sha512-vPei/HMimJgp4Ez0LFtNL399jLQaawDTVwsC5Fz7Y4Vsw4B6CP3rKlF6Y0RvY1TuFv5drK9cdA/dymRsvW7G7w==",
+			"dependencies": {
+				"@airgap/beacon-core": "4.0.4",
+				"@airgap/beacon-utils": "4.0.4",
+				"axios": "0.24.0"
+			}
+		},
+		"node_modules/@airgap/beacon-transport-postmessage": {
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/@airgap/beacon-transport-postmessage/-/beacon-transport-postmessage-4.0.4.tgz",
+			"integrity": "sha512-AdNPKEzoXo1lp4sgsMeeLEyHmZw/KnUVxSIjwoZpK+wn7E97uxJ6H+ecsq9zxpGtnoQ2Yt1AnSJJq8iofuwguA==",
+			"dependencies": {
+				"@airgap/beacon-core": "4.0.4",
+				"@airgap/beacon-types": "4.0.4",
+				"@airgap/beacon-utils": "4.0.4"
+			}
+		},
+		"node_modules/@airgap/beacon-transport-walletconnect": {
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/@airgap/beacon-transport-walletconnect/-/beacon-transport-walletconnect-4.0.4.tgz",
+			"integrity": "sha512-PBCErPUuE9oeixc7xeEYcwlJjnZ3WcCUs40SQ2tAE1N8uSkNX8D0kMb6r+WYHxWBjO91Uqq68x+3gPRXEIv6Kw==",
+			"dependencies": {
+				"@airgap/beacon-core": "4.0.4",
+				"@airgap/beacon-types": "4.0.4",
+				"@airgap/beacon-utils": "4.0.4",
+				"@walletconnect/sign-client": "^2.7.5"
+			}
+		},
+		"node_modules/@airgap/beacon-types": {
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/@airgap/beacon-types/-/beacon-types-4.0.4.tgz",
+			"integrity": "sha512-QIjsSkk+sdw9pcL6DybsQrlkHVqRmGFEr0N/YDlSNsnfGPH/q3O/dE+gfuiV93+bYM6WLbN4nd+nPt1xb0BCsw==",
+			"dependencies": {
+				"@types/chrome": "0.0.163"
+			}
+		},
+		"node_modules/@airgap/beacon-ui": {
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/@airgap/beacon-ui/-/beacon-ui-4.0.4.tgz",
+			"integrity": "sha512-QVVQGX272ebXS/JBRNwhbCqN7RDIG68nuQpil0dnrY8HMb9lVJV5GOuFIBf+3fyj6rpDbfyCKK3UgOSX1ZIrSA==",
+			"dependencies": {
+				"@airgap/beacon-core": "4.0.4",
+				"@airgap/beacon-transport-postmessage": "4.0.4",
+				"@airgap/beacon-types": "4.0.4",
+				"@airgap/beacon-utils": "4.0.4",
+				"qrcode-svg": "^1.1.0",
+				"solid-js": "^1.6.6"
+			}
+		},
+		"node_modules/@airgap/beacon-utils": {
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/@airgap/beacon-utils/-/beacon-utils-4.0.4.tgz",
+			"integrity": "sha512-95srMpUjwfE8BfdrDlApt4saxQsUI3z5LLXnjycTYCQ261eznQBhRjTHbYNPfNpw1wsvv/QN2T99FG06UOluIA==",
+			"dependencies": {
+				"@stablelib/ed25519": "^1.0.3",
+				"@stablelib/nacl": "^1.0.3",
+				"@stablelib/random": "^1.0.2",
+				"@stablelib/utf8": "^1.0.1",
+				"bs58check": "2.1.2"
+			}
+		},
+		"node_modules/@airgap/beacon-wallet": {
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/@airgap/beacon-wallet/-/beacon-wallet-4.0.4.tgz",
+			"integrity": "sha512-PWk0Mfhu9741soyGuJPPzbZuUx+UuRltoFJbyUMR8kd3gNb2yElrlldFoNJo7Tk/e/Ib/+nXYWQrbAfhjpRkCw==",
+			"dependencies": {
+				"@airgap/beacon-core": "4.0.4",
+				"@airgap/beacon-transport-matrix": "4.0.4",
+				"@airgap/beacon-transport-postmessage": "4.0.4"
+			}
+		},
 		"node_modules/@ampproject/remapping": {
 			"version": "2.2.1",
 			"resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.2.1.tgz",
 			"integrity": "sha512-lFMjJTrFL3j7L9yBxwYfCq2k6qqwHyzuUl/XBnif78PWTJYyL/dfowQHWE3sp6U6ZzqWiiIZnpTMO96zhkjwtg==",
-			"dev": true,
 			"dependencies": {
 				"@jridgewell/gen-mapping": "^0.3.0",
 				"@jridgewell/trace-mapping": "^0.3.9"
 			},
 			"engines": {
 				"node": ">=6.0.0"
+			}
+		},
+		"node_modules/@esbuild-plugins/node-globals-polyfill": {
+			"version": "0.2.3",
+			"resolved": "https://registry.npmjs.org/@esbuild-plugins/node-globals-polyfill/-/node-globals-polyfill-0.2.3.tgz",
+			"integrity": "sha512-r3MIryXDeXDOZh7ih1l/yE9ZLORCd5e8vWg02azWRGj5SPTuoh69A2AIyn0Z31V/kHBfZ4HgWJ+OK3GTTwLmnw==",
+			"peerDependencies": {
+				"esbuild": "*"
 			}
 		},
 		"node_modules/@esbuild/android-arm": {
@@ -53,7 +201,6 @@
 			"cpu": [
 				"arm"
 			],
-			"dev": true,
 			"optional": true,
 			"os": [
 				"android"
@@ -69,7 +216,6 @@
 			"cpu": [
 				"arm64"
 			],
-			"dev": true,
 			"optional": true,
 			"os": [
 				"android"
@@ -85,7 +231,6 @@
 			"cpu": [
 				"x64"
 			],
-			"dev": true,
 			"optional": true,
 			"os": [
 				"android"
@@ -101,7 +246,6 @@
 			"cpu": [
 				"arm64"
 			],
-			"dev": true,
 			"optional": true,
 			"os": [
 				"darwin"
@@ -117,7 +261,6 @@
 			"cpu": [
 				"x64"
 			],
-			"dev": true,
 			"optional": true,
 			"os": [
 				"darwin"
@@ -133,7 +276,6 @@
 			"cpu": [
 				"arm64"
 			],
-			"dev": true,
 			"optional": true,
 			"os": [
 				"freebsd"
@@ -149,7 +291,6 @@
 			"cpu": [
 				"x64"
 			],
-			"dev": true,
 			"optional": true,
 			"os": [
 				"freebsd"
@@ -165,7 +306,6 @@
 			"cpu": [
 				"arm"
 			],
-			"dev": true,
 			"optional": true,
 			"os": [
 				"linux"
@@ -181,7 +321,6 @@
 			"cpu": [
 				"arm64"
 			],
-			"dev": true,
 			"optional": true,
 			"os": [
 				"linux"
@@ -197,7 +336,6 @@
 			"cpu": [
 				"ia32"
 			],
-			"dev": true,
 			"optional": true,
 			"os": [
 				"linux"
@@ -213,7 +351,6 @@
 			"cpu": [
 				"loong64"
 			],
-			"dev": true,
 			"optional": true,
 			"os": [
 				"linux"
@@ -229,7 +366,6 @@
 			"cpu": [
 				"mips64el"
 			],
-			"dev": true,
 			"optional": true,
 			"os": [
 				"linux"
@@ -245,7 +381,6 @@
 			"cpu": [
 				"ppc64"
 			],
-			"dev": true,
 			"optional": true,
 			"os": [
 				"linux"
@@ -261,7 +396,6 @@
 			"cpu": [
 				"riscv64"
 			],
-			"dev": true,
 			"optional": true,
 			"os": [
 				"linux"
@@ -277,7 +411,6 @@
 			"cpu": [
 				"s390x"
 			],
-			"dev": true,
 			"optional": true,
 			"os": [
 				"linux"
@@ -293,7 +426,6 @@
 			"cpu": [
 				"x64"
 			],
-			"dev": true,
 			"optional": true,
 			"os": [
 				"linux"
@@ -309,7 +441,6 @@
 			"cpu": [
 				"x64"
 			],
-			"dev": true,
 			"optional": true,
 			"os": [
 				"netbsd"
@@ -325,7 +456,6 @@
 			"cpu": [
 				"x64"
 			],
-			"dev": true,
 			"optional": true,
 			"os": [
 				"openbsd"
@@ -341,7 +471,6 @@
 			"cpu": [
 				"x64"
 			],
-			"dev": true,
 			"optional": true,
 			"os": [
 				"sunos"
@@ -357,7 +486,6 @@
 			"cpu": [
 				"arm64"
 			],
-			"dev": true,
 			"optional": true,
 			"os": [
 				"win32"
@@ -373,7 +501,6 @@
 			"cpu": [
 				"ia32"
 			],
-			"dev": true,
 			"optional": true,
 			"os": [
 				"win32"
@@ -389,7 +516,6 @@
 			"cpu": [
 				"x64"
 			],
-			"dev": true,
 			"optional": true,
 			"os": [
 				"win32"
@@ -491,7 +617,6 @@
 			"version": "0.3.3",
 			"resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.3.tgz",
 			"integrity": "sha512-HLhSWOLRi875zjjMG/r+Nv0oCW8umGb0BgEhyX3dDX3egwZtB8PqLnjz3yedt8R5StBrzcg4aBpnh8UA9D1BoQ==",
-			"dev": true,
 			"dependencies": {
 				"@jridgewell/set-array": "^1.0.1",
 				"@jridgewell/sourcemap-codec": "^1.4.10",
@@ -505,7 +630,6 @@
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.0.tgz",
 			"integrity": "sha512-F2msla3tad+Mfht5cJq7LSXcdudKTWCVYUgw6pLFOOHSTtZlj6SWNYAp+AhuqLmWdBO2X5hPrLcu8cVP8fy28w==",
-			"dev": true,
 			"engines": {
 				"node": ">=6.0.0"
 			}
@@ -514,7 +638,6 @@
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.1.2.tgz",
 			"integrity": "sha512-xnkseuNADM0gt2bs+BvhO0p78Mk762YnZdsuzFV018NoG1Sj1SCQvpSqa7XUaTam5vAGasABV9qXASMKnFMwMw==",
-			"dev": true,
 			"engines": {
 				"node": ">=6.0.0"
 			}
@@ -522,14 +645,12 @@
 		"node_modules/@jridgewell/sourcemap-codec": {
 			"version": "1.4.15",
 			"resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.15.tgz",
-			"integrity": "sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg==",
-			"dev": true
+			"integrity": "sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg=="
 		},
 		"node_modules/@jridgewell/trace-mapping": {
 			"version": "0.3.18",
 			"resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.18.tgz",
 			"integrity": "sha512-w+niJYzMHdd7USdiH2U6869nqhD2nbfZXND5Yp93qIbEmnDNk7PD48o+YchRVpzMU7M6jVCbenTR7PA1FLQ9pA==",
-			"dev": true,
 			"dependencies": {
 				"@jridgewell/resolve-uri": "3.1.0",
 				"@jridgewell/sourcemap-codec": "1.4.14"
@@ -538,8 +659,7 @@
 		"node_modules/@jridgewell/trace-mapping/node_modules/@jridgewell/sourcemap-codec": {
 			"version": "1.4.14",
 			"resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.14.tgz",
-			"integrity": "sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw==",
-			"dev": true
+			"integrity": "sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw=="
 		},
 		"node_modules/@nodelib/fs.scandir": {
 			"version": "2.1.5",
@@ -581,6 +701,211 @@
 			"resolved": "https://registry.npmjs.org/@polka/url/-/url-1.0.0-next.21.tgz",
 			"integrity": "sha512-a5Sab1C4/icpTZVzZc5Ghpz88yQtGOyNqYXcZgOssB2uuAr+wF/MvN6bgtW32q7HHrvBki+BsZ0OuNv6EV3K9g==",
 			"dev": true
+		},
+		"node_modules/@stablelib/aead": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@stablelib/aead/-/aead-1.0.1.tgz",
+			"integrity": "sha512-q39ik6sxGHewqtO0nP4BuSe3db5G1fEJE8ukvngS2gLkBXyy6E7pLubhbYgnkDFv6V8cWaxcE4Xn0t6LWcJkyg=="
+		},
+		"node_modules/@stablelib/binary": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@stablelib/binary/-/binary-1.0.1.tgz",
+			"integrity": "sha512-ClJWvmL6UBM/wjkvv/7m5VP3GMr9t0osr4yVgLZsLCOz4hGN9gIAFEqnJ0TsSMAN+n840nf2cHZnA5/KFqHC7Q==",
+			"dependencies": {
+				"@stablelib/int": "^1.0.1"
+			}
+		},
+		"node_modules/@stablelib/blake2b": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@stablelib/blake2b/-/blake2b-1.0.1.tgz",
+			"integrity": "sha512-B3KyKoBAjkIFeH7romcF96i+pVFYk7K2SBQ1pZvaxV+epSBXJ+n0C66esUhyz6FF+5FbdQVm77C5fzGFcEZpKA==",
+			"dependencies": {
+				"@stablelib/binary": "^1.0.1",
+				"@stablelib/hash": "^1.0.1",
+				"@stablelib/wipe": "^1.0.1"
+			}
+		},
+		"node_modules/@stablelib/bytes": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@stablelib/bytes/-/bytes-1.0.1.tgz",
+			"integrity": "sha512-Kre4Y4kdwuqL8BR2E9hV/R5sOrUj6NanZaZis0V6lX5yzqC3hBuVSDXUIBqQv/sCpmuWRiHLwqiT1pqqjuBXoQ=="
+		},
+		"node_modules/@stablelib/chacha": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@stablelib/chacha/-/chacha-1.0.1.tgz",
+			"integrity": "sha512-Pmlrswzr0pBzDofdFuVe1q7KdsHKhhU24e8gkEwnTGOmlC7PADzLVxGdn2PoNVBBabdg0l/IfLKg6sHAbTQugg==",
+			"dependencies": {
+				"@stablelib/binary": "^1.0.1",
+				"@stablelib/wipe": "^1.0.1"
+			}
+		},
+		"node_modules/@stablelib/chacha20poly1305": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@stablelib/chacha20poly1305/-/chacha20poly1305-1.0.1.tgz",
+			"integrity": "sha512-MmViqnqHd1ymwjOQfghRKw2R/jMIGT3wySN7cthjXCBdO+qErNPUBnRzqNpnvIwg7JBCg3LdeCZZO4de/yEhVA==",
+			"dependencies": {
+				"@stablelib/aead": "^1.0.1",
+				"@stablelib/binary": "^1.0.1",
+				"@stablelib/chacha": "^1.0.1",
+				"@stablelib/constant-time": "^1.0.1",
+				"@stablelib/poly1305": "^1.0.1",
+				"@stablelib/wipe": "^1.0.1"
+			}
+		},
+		"node_modules/@stablelib/constant-time": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@stablelib/constant-time/-/constant-time-1.0.1.tgz",
+			"integrity": "sha512-tNOs3uD0vSJcK6z1fvef4Y+buN7DXhzHDPqRLSXUel1UfqMB1PWNsnnAezrKfEwTLpN0cGH2p9NNjs6IqeD0eg=="
+		},
+		"node_modules/@stablelib/ed25519": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/@stablelib/ed25519/-/ed25519-1.0.3.tgz",
+			"integrity": "sha512-puIMWaX9QlRsbhxfDc5i+mNPMY+0TmQEskunY1rZEBPi1acBCVQAhnsk/1Hk50DGPtVsZtAWQg4NHGlVaO9Hqg==",
+			"dependencies": {
+				"@stablelib/random": "^1.0.2",
+				"@stablelib/sha512": "^1.0.1",
+				"@stablelib/wipe": "^1.0.1"
+			}
+		},
+		"node_modules/@stablelib/hash": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@stablelib/hash/-/hash-1.0.1.tgz",
+			"integrity": "sha512-eTPJc/stDkdtOcrNMZ6mcMK1e6yBbqRBaNW55XA1jU8w/7QdnCF0CmMmOD1m7VSkBR44PWrMHU2l6r8YEQHMgg=="
+		},
+		"node_modules/@stablelib/hkdf": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@stablelib/hkdf/-/hkdf-1.0.1.tgz",
+			"integrity": "sha512-SBEHYE16ZXlHuaW5RcGk533YlBj4grMeg5TooN80W3NpcHRtLZLLXvKyX0qcRFxf+BGDobJLnwkvgEwHIDBR6g==",
+			"dependencies": {
+				"@stablelib/hash": "^1.0.1",
+				"@stablelib/hmac": "^1.0.1",
+				"@stablelib/wipe": "^1.0.1"
+			}
+		},
+		"node_modules/@stablelib/hmac": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@stablelib/hmac/-/hmac-1.0.1.tgz",
+			"integrity": "sha512-V2APD9NSnhVpV/QMYgCVMIYKiYG6LSqw1S65wxVoirhU/51ACio6D4yDVSwMzuTJXWZoVHbDdINioBwKy5kVmA==",
+			"dependencies": {
+				"@stablelib/constant-time": "^1.0.1",
+				"@stablelib/hash": "^1.0.1",
+				"@stablelib/wipe": "^1.0.1"
+			}
+		},
+		"node_modules/@stablelib/int": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@stablelib/int/-/int-1.0.1.tgz",
+			"integrity": "sha512-byr69X/sDtDiIjIV6m4roLVWnNNlRGzsvxw+agj8CIEazqWGOQp2dTYgQhtyVXV9wpO6WyXRQUzLV/JRNumT2w=="
+		},
+		"node_modules/@stablelib/keyagreement": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@stablelib/keyagreement/-/keyagreement-1.0.1.tgz",
+			"integrity": "sha512-VKL6xBwgJnI6l1jKrBAfn265cspaWBPAPEc62VBQrWHLqVgNRE09gQ/AnOEyKUWrrqfD+xSQ3u42gJjLDdMDQg==",
+			"dependencies": {
+				"@stablelib/bytes": "^1.0.1"
+			}
+		},
+		"node_modules/@stablelib/nacl": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/@stablelib/nacl/-/nacl-1.0.4.tgz",
+			"integrity": "sha512-PJ2U/MrkXSKUM8C4qFs87WeCNxri7KQwR8Cdwm9q2sweGuAtTvOJGuW0F3N+zn+ySLPJA98SYWSSpogMJ1gCmw==",
+			"dependencies": {
+				"@stablelib/poly1305": "^1.0.1",
+				"@stablelib/random": "^1.0.2",
+				"@stablelib/wipe": "^1.0.1",
+				"@stablelib/x25519": "^1.0.3",
+				"@stablelib/xsalsa20": "^1.0.2"
+			}
+		},
+		"node_modules/@stablelib/poly1305": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@stablelib/poly1305/-/poly1305-1.0.1.tgz",
+			"integrity": "sha512-1HlG3oTSuQDOhSnLwJRKeTRSAdFNVB/1djy2ZbS35rBSJ/PFqx9cf9qatinWghC2UbfOYD8AcrtbUQl8WoxabA==",
+			"dependencies": {
+				"@stablelib/constant-time": "^1.0.1",
+				"@stablelib/wipe": "^1.0.1"
+			}
+		},
+		"node_modules/@stablelib/random": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/@stablelib/random/-/random-1.0.2.tgz",
+			"integrity": "sha512-rIsE83Xpb7clHPVRlBj8qNe5L8ISQOzjghYQm/dZ7VaM2KHYwMW5adjQjrzTZCchFnNCNhkwtnOBa9HTMJCI8w==",
+			"dependencies": {
+				"@stablelib/binary": "^1.0.1",
+				"@stablelib/wipe": "^1.0.1"
+			}
+		},
+		"node_modules/@stablelib/salsa20": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/@stablelib/salsa20/-/salsa20-1.0.2.tgz",
+			"integrity": "sha512-nfjKzw0KTKrrKBasEP+j7UP4I8Xudom8lVZIBCp0kQNARXq72IlSic0oabg2FC1NU68L4RdHrNJDd8bFwrphYA==",
+			"dependencies": {
+				"@stablelib/binary": "^1.0.1",
+				"@stablelib/constant-time": "^1.0.1",
+				"@stablelib/wipe": "^1.0.1"
+			}
+		},
+		"node_modules/@stablelib/sha256": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@stablelib/sha256/-/sha256-1.0.1.tgz",
+			"integrity": "sha512-GIIH3e6KH+91FqGV42Kcj71Uefd/QEe7Dy42sBTeqppXV95ggCcxLTk39bEr+lZfJmp+ghsR07J++ORkRELsBQ==",
+			"dependencies": {
+				"@stablelib/binary": "^1.0.1",
+				"@stablelib/hash": "^1.0.1",
+				"@stablelib/wipe": "^1.0.1"
+			}
+		},
+		"node_modules/@stablelib/sha512": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@stablelib/sha512/-/sha512-1.0.1.tgz",
+			"integrity": "sha512-13gl/iawHV9zvDKciLo1fQ8Bgn2Pvf7OV6amaRVKiq3pjQ3UmEpXxWiAfV8tYjUpeZroBxtyrwtdooQT/i3hzw==",
+			"dependencies": {
+				"@stablelib/binary": "^1.0.1",
+				"@stablelib/hash": "^1.0.1",
+				"@stablelib/wipe": "^1.0.1"
+			}
+		},
+		"node_modules/@stablelib/utf8": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@stablelib/utf8/-/utf8-1.0.1.tgz",
+			"integrity": "sha512-FrYD1xadah/TtAP6VJ04lDD5h9rdDj/d8wH/jMYTtHqZBv9z2btdvEU8vTxdjdkFmo1b/BH+t3R1wi/mYhCCNg=="
+		},
+		"node_modules/@stablelib/wipe": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@stablelib/wipe/-/wipe-1.0.1.tgz",
+			"integrity": "sha512-WfqfX/eXGiAd3RJe4VU2snh/ZPwtSjLG4ynQ/vYzvghTh7dHFcI1wl+nrkWG6lGhukOxOsUHfv8dUXr58D0ayg=="
+		},
+		"node_modules/@stablelib/x25519": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/@stablelib/x25519/-/x25519-1.0.3.tgz",
+			"integrity": "sha512-KnTbKmUhPhHavzobclVJQG5kuivH+qDLpe84iRqX3CLrKp881cF160JvXJ+hjn1aMyCwYOKeIZefIH/P5cJoRw==",
+			"dependencies": {
+				"@stablelib/keyagreement": "^1.0.1",
+				"@stablelib/random": "^1.0.2",
+				"@stablelib/wipe": "^1.0.1"
+			}
+		},
+		"node_modules/@stablelib/x25519-session": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/@stablelib/x25519-session/-/x25519-session-1.0.4.tgz",
+			"integrity": "sha512-UZw67EJWSNTaou7Qp086fzGek7crrCQl2K7MoqEzslXxrm6vybySfcdsqaZ0ZpKq19IHWK8G0wAlFBy70srm3w==",
+			"dependencies": {
+				"@stablelib/blake2b": "^1.0.1",
+				"@stablelib/keyagreement": "^1.0.1",
+				"@stablelib/random": "^1.0.2",
+				"@stablelib/wipe": "^1.0.1",
+				"@stablelib/x25519": "^1.0.3"
+			}
+		},
+		"node_modules/@stablelib/xsalsa20": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/@stablelib/xsalsa20/-/xsalsa20-1.0.2.tgz",
+			"integrity": "sha512-7XdBGbcNgBShmuhDXv1G1WPVCkjZdkb1oPMzSidO7Fve0MHntH6TjFkj5bfLI+aRE+61weO076vYpP/jmaAYog==",
+			"dependencies": {
+				"@stablelib/binary": "^1.0.1",
+				"@stablelib/salsa20": "^1.0.2",
+				"@stablelib/wipe": "^1.0.1"
+			}
 		},
 		"node_modules/@sveltejs/adapter-auto": {
 			"version": "2.1.0",
@@ -664,6 +989,336 @@
 				"vite": "^4.0.0"
 			}
 		},
+		"node_modules/@taquito/beacon-wallet": {
+			"version": "17.0.0",
+			"resolved": "https://registry.npmjs.org/@taquito/beacon-wallet/-/beacon-wallet-17.0.0.tgz",
+			"integrity": "sha512-OKuN2V2xLMeSb0u3nfzSjZDYV4mIB4pur2eR8xa+NhkXlY0gkQXjmZ3K9lwtjKcU3GI0iv5IVod4blYyHNeNvg==",
+			"dependencies": {
+				"@airgap/beacon-dapp": "4.0.2",
+				"@taquito/core": "^17.0.0",
+				"@taquito/taquito": "^17.0.0"
+			},
+			"engines": {
+				"node": ">=16"
+			}
+		},
+		"node_modules/@taquito/beacon-wallet/node_modules/@airgap/beacon-core": {
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/@airgap/beacon-core/-/beacon-core-4.0.2.tgz",
+			"integrity": "sha512-a6mAn6BfbejBQI95tRc6pIZ0VS6MTK9MZ7iXPTLF9hrnCHiROmrCgNKst8qp2dcE0Ehk7z/hGs2WliJzi657YA==",
+			"dependencies": {
+				"@airgap/beacon-types": "4.0.2",
+				"@airgap/beacon-utils": "4.0.2",
+				"@stablelib/ed25519": "^1.0.3",
+				"@stablelib/nacl": "^1.0.4",
+				"@stablelib/utf8": "^1.0.1",
+				"@stablelib/x25519-session": "^1.0.4",
+				"bs58check": "2.1.2"
+			}
+		},
+		"node_modules/@taquito/beacon-wallet/node_modules/@airgap/beacon-dapp": {
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/@airgap/beacon-dapp/-/beacon-dapp-4.0.2.tgz",
+			"integrity": "sha512-7vjvcM470GPfDkizYpuUzJ7Fus7X/zkFeXYTkxx69Dt5TlmKg09YNfRtvrFMDbf4OKnjbaRfVhqzwfYkpaRbPg==",
+			"dependencies": {
+				"@airgap/beacon-core": "4.0.2",
+				"@airgap/beacon-transport-matrix": "4.0.2",
+				"@airgap/beacon-transport-postmessage": "4.0.2",
+				"@airgap/beacon-transport-walletconnect": "4.0.2",
+				"@airgap/beacon-ui": "4.0.2"
+			}
+		},
+		"node_modules/@taquito/beacon-wallet/node_modules/@airgap/beacon-transport-matrix": {
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/@airgap/beacon-transport-matrix/-/beacon-transport-matrix-4.0.2.tgz",
+			"integrity": "sha512-sidXWA9QkcdpTLObsgMIIePq2+6eHn8djSK2UeoAWZpVOky+jpaIU78UlzqgDzMrO9inzu/xwsuXlk5Nmy1RyA==",
+			"dependencies": {
+				"@airgap/beacon-core": "4.0.2",
+				"@airgap/beacon-utils": "4.0.2",
+				"axios": "0.24.0"
+			}
+		},
+		"node_modules/@taquito/beacon-wallet/node_modules/@airgap/beacon-transport-postmessage": {
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/@airgap/beacon-transport-postmessage/-/beacon-transport-postmessage-4.0.2.tgz",
+			"integrity": "sha512-UDHigcIRD5/VdKX3YDj+CVHYWafYg3N8nHT5yQ2JOU5nsQhD2y5NNNp/7U7I44CcD4OeK9d2slV+lnp8lBYe1g==",
+			"dependencies": {
+				"@airgap/beacon-core": "4.0.2",
+				"@airgap/beacon-types": "4.0.2",
+				"@airgap/beacon-utils": "4.0.2"
+			}
+		},
+		"node_modules/@taquito/beacon-wallet/node_modules/@airgap/beacon-transport-walletconnect": {
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/@airgap/beacon-transport-walletconnect/-/beacon-transport-walletconnect-4.0.2.tgz",
+			"integrity": "sha512-t4ZrgyImVf8UIhVa6ei/p1STVKNdRq5WSoop8eTSqArIHVj4zk2dr5J0ihbe64UyLAX1O0Z7yV+dUVoH+kVWGw==",
+			"dependencies": {
+				"@airgap/beacon-core": "4.0.2",
+				"@airgap/beacon-types": "4.0.2",
+				"@airgap/beacon-utils": "4.0.2",
+				"@walletconnect/sign-client": "2.7.0"
+			}
+		},
+		"node_modules/@taquito/beacon-wallet/node_modules/@airgap/beacon-types": {
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/@airgap/beacon-types/-/beacon-types-4.0.2.tgz",
+			"integrity": "sha512-MWbE+350Yd7aICBEwTVIkty/YmKO5eTDsMbReUCNH8qf64gGhj/ZXEN6FPwMab+qKdmACgCkmbbtAXGGtmjwrA==",
+			"dependencies": {
+				"@types/chrome": "0.0.163"
+			}
+		},
+		"node_modules/@taquito/beacon-wallet/node_modules/@airgap/beacon-ui": {
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/@airgap/beacon-ui/-/beacon-ui-4.0.2.tgz",
+			"integrity": "sha512-ZTcvdQ5GNlQ58M0Fduoq/KqsulBXeBN6jKiHnzHM3e98syy953DKQoDhU2NXNZiJ7AvEGO3s/fd+BN8y/+CVuQ==",
+			"dependencies": {
+				"@airgap/beacon-core": "4.0.2",
+				"@airgap/beacon-transport-postmessage": "4.0.2",
+				"@airgap/beacon-types": "4.0.2",
+				"@airgap/beacon-utils": "4.0.2",
+				"qrcode-svg": "^1.1.0",
+				"solid-js": "^1.6.6"
+			}
+		},
+		"node_modules/@taquito/beacon-wallet/node_modules/@airgap/beacon-utils": {
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/@airgap/beacon-utils/-/beacon-utils-4.0.2.tgz",
+			"integrity": "sha512-5TfOI3ZolQQ9WNHogEO3SY4M2Paqbb3hf8DvolFofST6Brp0qyxkwZ0i99puahgwRo+B0qGilZpkLCYl72DMQg==",
+			"dependencies": {
+				"@stablelib/ed25519": "^1.0.3",
+				"@stablelib/nacl": "^1.0.3",
+				"@stablelib/random": "^1.0.2",
+				"@stablelib/utf8": "^1.0.1",
+				"bs58check": "2.1.2"
+			}
+		},
+		"node_modules/@taquito/beacon-wallet/node_modules/@walletconnect/core": {
+			"version": "2.7.0",
+			"resolved": "https://registry.npmjs.org/@walletconnect/core/-/core-2.7.0.tgz",
+			"integrity": "sha512-xUeFPpElybgn1a+lknqtHleei4VyuV/4qWgB1nP8qQUAO6a5pNsioODrnB2VAPdUHJYBdx2dCt2maRk6g53IPQ==",
+			"dependencies": {
+				"@walletconnect/heartbeat": "1.2.1",
+				"@walletconnect/jsonrpc-provider": "^1.0.12",
+				"@walletconnect/jsonrpc-utils": "^1.0.7",
+				"@walletconnect/jsonrpc-ws-connection": "^1.0.11",
+				"@walletconnect/keyvaluestorage": "^1.0.2",
+				"@walletconnect/logger": "^2.0.1",
+				"@walletconnect/relay-api": "^1.0.9",
+				"@walletconnect/relay-auth": "^1.0.4",
+				"@walletconnect/safe-json": "^1.0.2",
+				"@walletconnect/time": "^1.0.2",
+				"@walletconnect/types": "2.7.0",
+				"@walletconnect/utils": "2.7.0",
+				"events": "^3.3.0",
+				"lodash.isequal": "4.5.0",
+				"uint8arrays": "^3.1.0"
+			}
+		},
+		"node_modules/@taquito/beacon-wallet/node_modules/@walletconnect/sign-client": {
+			"version": "2.7.0",
+			"resolved": "https://registry.npmjs.org/@walletconnect/sign-client/-/sign-client-2.7.0.tgz",
+			"integrity": "sha512-K99xa6GSFS04U+140yrIEi/VJJJ0Q1ov4jCaiqa9euILDKxlBsM7m5GR+9sq6oYyj18SluJY4CJTdeOXUJlarA==",
+			"dependencies": {
+				"@walletconnect/core": "2.7.0",
+				"@walletconnect/events": "^1.0.1",
+				"@walletconnect/heartbeat": "1.2.1",
+				"@walletconnect/jsonrpc-utils": "^1.0.7",
+				"@walletconnect/logger": "^2.0.1",
+				"@walletconnect/time": "^1.0.2",
+				"@walletconnect/types": "2.7.0",
+				"@walletconnect/utils": "2.7.0",
+				"events": "^3.3.0"
+			}
+		},
+		"node_modules/@taquito/beacon-wallet/node_modules/@walletconnect/types": {
+			"version": "2.7.0",
+			"resolved": "https://registry.npmjs.org/@walletconnect/types/-/types-2.7.0.tgz",
+			"integrity": "sha512-aMUDUtO79WSBtC/bDetE6aFwdgwJr0tJ8nC8gnAl5ELsrjygEKCn6M8Q+v6nP9svG9yf5Rds4cImxCT6BWwTyw==",
+			"dependencies": {
+				"@walletconnect/events": "^1.0.1",
+				"@walletconnect/heartbeat": "1.2.1",
+				"@walletconnect/jsonrpc-types": "^1.0.2",
+				"@walletconnect/keyvaluestorage": "^1.0.2",
+				"@walletconnect/logger": "^2.0.1",
+				"events": "^3.3.0"
+			}
+		},
+		"node_modules/@taquito/beacon-wallet/node_modules/@walletconnect/utils": {
+			"version": "2.7.0",
+			"resolved": "https://registry.npmjs.org/@walletconnect/utils/-/utils-2.7.0.tgz",
+			"integrity": "sha512-k32jrQeyJsNZPdmtmg85Y3QgaS5YfzYSPrAxRC2uUD1ts7rrI6P5GG2iXNs3AvWKOuCgsp/PqU8s7AC7CRUscw==",
+			"dependencies": {
+				"@stablelib/chacha20poly1305": "1.0.1",
+				"@stablelib/hkdf": "1.0.1",
+				"@stablelib/random": "^1.0.2",
+				"@stablelib/sha256": "1.0.1",
+				"@stablelib/x25519": "^1.0.3",
+				"@walletconnect/jsonrpc-utils": "^1.0.7",
+				"@walletconnect/relay-api": "^1.0.9",
+				"@walletconnect/safe-json": "^1.0.2",
+				"@walletconnect/time": "^1.0.2",
+				"@walletconnect/types": "2.7.0",
+				"@walletconnect/window-getters": "^1.0.1",
+				"@walletconnect/window-metadata": "^1.0.1",
+				"detect-browser": "5.3.0",
+				"query-string": "7.1.1",
+				"uint8arrays": "^3.1.0"
+			}
+		},
+		"node_modules/@taquito/beacon-wallet/node_modules/query-string": {
+			"version": "7.1.1",
+			"resolved": "https://registry.npmjs.org/query-string/-/query-string-7.1.1.tgz",
+			"integrity": "sha512-MplouLRDHBZSG9z7fpuAAcI7aAYjDLhtsiVZsevsfaHWDS2IDdORKbSd1kWUA+V4zyva/HZoSfpwnYMMQDhb0w==",
+			"dependencies": {
+				"decode-uri-component": "^0.2.0",
+				"filter-obj": "^1.1.0",
+				"split-on-first": "^1.0.0",
+				"strict-uri-encode": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=6"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/@taquito/core": {
+			"version": "17.0.0",
+			"resolved": "https://registry.npmjs.org/@taquito/core/-/core-17.0.0.tgz",
+			"integrity": "sha512-N+ww8+whR8T07XZLlcEyjTQCYfAZif9s1dTqagWW0V9l/EIXsnl1tL2MBfZnVcJDMhKoIk1MjofS0gYc0hld2Q==",
+			"engines": {
+				"node": ">=16"
+			}
+		},
+		"node_modules/@taquito/http-utils": {
+			"version": "17.0.0",
+			"resolved": "https://registry.npmjs.org/@taquito/http-utils/-/http-utils-17.0.0.tgz",
+			"integrity": "sha512-oyzZEr7k/HUQotFGGegXyixmUOB9jWsypTjWDmuElutDmO0GjFh33zii7vn57kZ1GmX4f0z45yiBp0w3flvhbA==",
+			"dependencies": {
+				"@taquito/core": "^17.0.0",
+				"axios": "^0.26.0"
+			},
+			"engines": {
+				"node": ">=16"
+			}
+		},
+		"node_modules/@taquito/http-utils/node_modules/axios": {
+			"version": "0.26.1",
+			"resolved": "https://registry.npmjs.org/axios/-/axios-0.26.1.tgz",
+			"integrity": "sha512-fPwcX4EvnSHuInCMItEhAGnaSEXRBjtzh9fOtsE6E1G6p7vl7edEeZe11QHf18+6+9gR5PbKV/sGKNaD8YaMeA==",
+			"dependencies": {
+				"follow-redirects": "^1.14.8"
+			}
+		},
+		"node_modules/@taquito/local-forging": {
+			"version": "17.0.0",
+			"resolved": "https://registry.npmjs.org/@taquito/local-forging/-/local-forging-17.0.0.tgz",
+			"integrity": "sha512-5VSbNGFb9WX9o/7mg49PjnwNeYMbf4JRZvrmxxWcffvfaNFnNW5X1iys+I7kHQA6HivhX73d6lVBiJkq2cQ3ag==",
+			"dependencies": {
+				"@taquito/core": "^17.0.0",
+				"@taquito/utils": "^17.0.0",
+				"bignumber.js": "^9.1.0"
+			},
+			"engines": {
+				"node": ">=16"
+			}
+		},
+		"node_modules/@taquito/michel-codec": {
+			"version": "17.0.0",
+			"resolved": "https://registry.npmjs.org/@taquito/michel-codec/-/michel-codec-17.0.0.tgz",
+			"integrity": "sha512-0wD4r1bfBzoZ3QpxN7grD/gHt8RcNehQ7Ped4quKh4iGmNmd4ej+/LEvw/kX5082M4mGbUMC0UwH2Go+J6C1ow==",
+			"dependencies": {
+				"@taquito/core": "^17.0.0"
+			},
+			"engines": {
+				"node": ">=16"
+			}
+		},
+		"node_modules/@taquito/michelson-encoder": {
+			"version": "17.0.0",
+			"resolved": "https://registry.npmjs.org/@taquito/michelson-encoder/-/michelson-encoder-17.0.0.tgz",
+			"integrity": "sha512-K2y8i7qjniWwjgI2illmBSiWO5B7zYBwTPS+CMw9OsxfMSaw5z8x4dMeBw5Bumc1p2SWo/jcU9U5qOnTVpxdeg==",
+			"dependencies": {
+				"@taquito/rpc": "^17.0.0",
+				"@taquito/utils": "^17.0.0",
+				"bignumber.js": "^9.1.0",
+				"fast-json-stable-stringify": "^2.1.0"
+			},
+			"engines": {
+				"node": ">=16"
+			}
+		},
+		"node_modules/@taquito/rpc": {
+			"version": "17.0.0",
+			"resolved": "https://registry.npmjs.org/@taquito/rpc/-/rpc-17.0.0.tgz",
+			"integrity": "sha512-5btSJNvdfHdoftXqUWheVh5pxos6YlmRb7q1A2z9Y49ocjz7wqr4aCuXeRsG1iESZ69V2DUr33t51joidVsDXA==",
+			"dependencies": {
+				"@taquito/core": "^17.0.0",
+				"@taquito/http-utils": "^17.0.0",
+				"@taquito/utils": "^17.0.0",
+				"bignumber.js": "^9.1.0"
+			},
+			"engines": {
+				"node": ">=16"
+			}
+		},
+		"node_modules/@taquito/taquito": {
+			"version": "17.0.0",
+			"resolved": "https://registry.npmjs.org/@taquito/taquito/-/taquito-17.0.0.tgz",
+			"integrity": "sha512-yLrP6lbgO4k1a9PoTDZxIasYmc3QxEJ4R59vgPPIlWQJfz0ZTBV9fPQNlwyTtRjjzgvX1gRN1VtpuddkcGjKrA==",
+			"hasInstallScript": true,
+			"dependencies": {
+				"@taquito/core": "^17.0.0",
+				"@taquito/http-utils": "^17.0.0",
+				"@taquito/local-forging": "^17.0.0",
+				"@taquito/michel-codec": "^17.0.0",
+				"@taquito/michelson-encoder": "^17.0.0",
+				"@taquito/rpc": "^17.0.0",
+				"@taquito/utils": "^17.0.0",
+				"bignumber.js": "^9.1.0",
+				"rxjs": "^6.6.3"
+			},
+			"engines": {
+				"node": ">=16"
+			}
+		},
+		"node_modules/@taquito/utils": {
+			"version": "17.0.0",
+			"resolved": "https://registry.npmjs.org/@taquito/utils/-/utils-17.0.0.tgz",
+			"integrity": "sha512-/Bg4UoQenriINVK727OpK0AWe1x1SFSdiRZD3cGMMu2fXaFQdG2Hx031bf46GN+Tqk/PuDchjA83UfQk05qBXQ==",
+			"dependencies": {
+				"@stablelib/blake2b": "^1.0.1",
+				"@stablelib/ed25519": "^1.0.3",
+				"@taquito/core": "^17.0.0",
+				"@types/bs58check": "^2.1.0",
+				"bignumber.js": "^9.1.0",
+				"blakejs": "^1.2.1",
+				"bs58check": "^2.1.2",
+				"buffer": "^6.0.3",
+				"elliptic": "^6.5.4",
+				"typedarray-to-buffer": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=16"
+			}
+		},
+		"node_modules/@types/bs58check": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/@types/bs58check/-/bs58check-2.1.0.tgz",
+			"integrity": "sha512-OxsysnJQh82vy9DRbOcw9m2j/WiyqZLn0YBhKxdQ+aCwoHj+tWzyCgpwAkr79IfDXZKxc6h7k89T9pwS78CqTQ==",
+			"dependencies": {
+				"@types/node": "*"
+			}
+		},
+		"node_modules/@types/chrome": {
+			"version": "0.0.163",
+			"resolved": "https://registry.npmjs.org/@types/chrome/-/chrome-0.0.163.tgz",
+			"integrity": "sha512-g+3E2tg/ukFsEgH+tB3a/b+J1VSvq/8gh2Jwih9eq+T3Idrz7ngj97u+/ya58Bfei2TQtPlRivj1FsCaSnukDA==",
+			"dependencies": {
+				"@types/filesystem": "*",
+				"@types/har-format": "*"
+			}
+		},
 		"node_modules/@types/cookie": {
 			"version": "0.5.1",
 			"resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.5.1.tgz",
@@ -673,14 +1328,36 @@
 		"node_modules/@types/estree": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.1.tgz",
-			"integrity": "sha512-LG4opVs2ANWZ1TJoKc937iMmNstM/d0ae1vNbnBvBhqCSezgVUOzcLCqbI5elV8Vy6WKwKjaqR+zO9VKirBBCA==",
-			"dev": true
+			"integrity": "sha512-LG4opVs2ANWZ1TJoKc937iMmNstM/d0ae1vNbnBvBhqCSezgVUOzcLCqbI5elV8Vy6WKwKjaqR+zO9VKirBBCA=="
+		},
+		"node_modules/@types/filesystem": {
+			"version": "0.0.32",
+			"resolved": "https://registry.npmjs.org/@types/filesystem/-/filesystem-0.0.32.tgz",
+			"integrity": "sha512-Yuf4jR5YYMR2DVgwuCiP11s0xuVRyPKmz8vo6HBY3CGdeMj8af93CFZX+T82+VD1+UqHOxTq31lO7MI7lepBtQ==",
+			"dependencies": {
+				"@types/filewriter": "*"
+			}
+		},
+		"node_modules/@types/filewriter": {
+			"version": "0.0.29",
+			"resolved": "https://registry.npmjs.org/@types/filewriter/-/filewriter-0.0.29.tgz",
+			"integrity": "sha512-BsPXH/irW0ht0Ji6iw/jJaK8Lj3FJemon2gvEqHKpCdDCeemHa+rI3WBGq5z7cDMZgoLjY40oninGxqk+8NzNQ=="
+		},
+		"node_modules/@types/har-format": {
+			"version": "1.2.11",
+			"resolved": "https://registry.npmjs.org/@types/har-format/-/har-format-1.2.11.tgz",
+			"integrity": "sha512-T232/TneofqK30AD1LRrrf8KnjLvzrjWDp7eWST5KoiSzrBfRsLrWDPk4STQPW4NZG6v2MltnduBVmakbZOBIQ=="
 		},
 		"node_modules/@types/json-schema": {
 			"version": "7.0.12",
 			"resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.12.tgz",
 			"integrity": "sha512-Hr5Jfhc9eYOQNPYO5WLDq/n4jqijdHNlDXjuAQkkt+mWdQR+XJToOHrsD4cPaMXpn6KO7y2+wM8AZEs8VpBLVA==",
 			"dev": true
+		},
+		"node_modules/@types/node": {
+			"version": "20.3.3",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-20.3.3.tgz",
+			"integrity": "sha512-wheIYdr4NYML61AjC8MKj/2jrR/kDQri/CIpVoZwldwhnIrD/j9jIU5bJ8yBKuB2VhpFV7Ab6G2XkBjv9r9Zzw=="
 		},
 		"node_modules/@types/pug": {
 			"version": "2.0.6",
@@ -882,11 +1559,311 @@
 				"url": "https://opencollective.com/typescript-eslint"
 			}
 		},
+		"node_modules/@walletconnect/core": {
+			"version": "2.8.6",
+			"resolved": "https://registry.npmjs.org/@walletconnect/core/-/core-2.8.6.tgz",
+			"integrity": "sha512-rnSqm1KJLcww/v6+UH8JeibQkJ3EKgyUDPfEK0stSEkrIUIcXaFlq3Et8S+vgV8bPhI0MVUhAhFL5OJZ3t2ryg==",
+			"dependencies": {
+				"@walletconnect/heartbeat": "1.2.1",
+				"@walletconnect/jsonrpc-provider": "1.0.13",
+				"@walletconnect/jsonrpc-types": "1.0.3",
+				"@walletconnect/jsonrpc-utils": "1.0.8",
+				"@walletconnect/jsonrpc-ws-connection": "^1.0.11",
+				"@walletconnect/keyvaluestorage": "^1.0.2",
+				"@walletconnect/logger": "^2.0.1",
+				"@walletconnect/relay-api": "^1.0.9",
+				"@walletconnect/relay-auth": "^1.0.4",
+				"@walletconnect/safe-json": "^1.0.2",
+				"@walletconnect/time": "^1.0.2",
+				"@walletconnect/types": "2.8.6",
+				"@walletconnect/utils": "2.8.6",
+				"events": "^3.3.0",
+				"lodash.isequal": "4.5.0",
+				"uint8arrays": "^3.1.0"
+			}
+		},
+		"node_modules/@walletconnect/environment": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@walletconnect/environment/-/environment-1.0.1.tgz",
+			"integrity": "sha512-T426LLZtHj8e8rYnKfzsw1aG6+M0BT1ZxayMdv/p8yM0MU+eJDISqNY3/bccxRr4LrF9csq02Rhqt08Ibl0VRg==",
+			"dependencies": {
+				"tslib": "1.14.1"
+			}
+		},
+		"node_modules/@walletconnect/environment/node_modules/tslib": {
+			"version": "1.14.1",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+			"integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+		},
+		"node_modules/@walletconnect/events": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@walletconnect/events/-/events-1.0.1.tgz",
+			"integrity": "sha512-NPTqaoi0oPBVNuLv7qPaJazmGHs5JGyO8eEAk5VGKmJzDR7AHzD4k6ilox5kxk1iwiOnFopBOOMLs86Oa76HpQ==",
+			"dependencies": {
+				"keyvaluestorage-interface": "^1.0.0",
+				"tslib": "1.14.1"
+			}
+		},
+		"node_modules/@walletconnect/events/node_modules/tslib": {
+			"version": "1.14.1",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+			"integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+		},
+		"node_modules/@walletconnect/heartbeat": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/@walletconnect/heartbeat/-/heartbeat-1.2.1.tgz",
+			"integrity": "sha512-yVzws616xsDLJxuG/28FqtZ5rzrTA4gUjdEMTbWB5Y8V1XHRmqq4efAxCw5ie7WjbXFSUyBHaWlMR+2/CpQC5Q==",
+			"dependencies": {
+				"@walletconnect/events": "^1.0.1",
+				"@walletconnect/time": "^1.0.2",
+				"tslib": "1.14.1"
+			}
+		},
+		"node_modules/@walletconnect/heartbeat/node_modules/tslib": {
+			"version": "1.14.1",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+			"integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+		},
+		"node_modules/@walletconnect/jsonrpc-provider": {
+			"version": "1.0.13",
+			"resolved": "https://registry.npmjs.org/@walletconnect/jsonrpc-provider/-/jsonrpc-provider-1.0.13.tgz",
+			"integrity": "sha512-K73EpThqHnSR26gOyNEL+acEex3P7VWZe6KE12ZwKzAt2H4e5gldZHbjsu2QR9cLeJ8AXuO7kEMOIcRv1QEc7g==",
+			"dependencies": {
+				"@walletconnect/jsonrpc-utils": "^1.0.8",
+				"@walletconnect/safe-json": "^1.0.2",
+				"tslib": "1.14.1"
+			}
+		},
+		"node_modules/@walletconnect/jsonrpc-provider/node_modules/tslib": {
+			"version": "1.14.1",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+			"integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+		},
+		"node_modules/@walletconnect/jsonrpc-types": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/@walletconnect/jsonrpc-types/-/jsonrpc-types-1.0.3.tgz",
+			"integrity": "sha512-iIQ8hboBl3o5ufmJ8cuduGad0CQm3ZlsHtujv9Eu16xq89q+BG7Nh5VLxxUgmtpnrePgFkTwXirCTkwJH1v+Yw==",
+			"dependencies": {
+				"keyvaluestorage-interface": "^1.0.0",
+				"tslib": "1.14.1"
+			}
+		},
+		"node_modules/@walletconnect/jsonrpc-types/node_modules/tslib": {
+			"version": "1.14.1",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+			"integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+		},
+		"node_modules/@walletconnect/jsonrpc-utils": {
+			"version": "1.0.8",
+			"resolved": "https://registry.npmjs.org/@walletconnect/jsonrpc-utils/-/jsonrpc-utils-1.0.8.tgz",
+			"integrity": "sha512-vdeb03bD8VzJUL6ZtzRYsFMq1eZQcM3EAzT0a3st59dyLfJ0wq+tKMpmGH7HlB7waD858UWgfIcudbPFsbzVdw==",
+			"dependencies": {
+				"@walletconnect/environment": "^1.0.1",
+				"@walletconnect/jsonrpc-types": "^1.0.3",
+				"tslib": "1.14.1"
+			}
+		},
+		"node_modules/@walletconnect/jsonrpc-utils/node_modules/tslib": {
+			"version": "1.14.1",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+			"integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+		},
+		"node_modules/@walletconnect/jsonrpc-ws-connection": {
+			"version": "1.0.12",
+			"resolved": "https://registry.npmjs.org/@walletconnect/jsonrpc-ws-connection/-/jsonrpc-ws-connection-1.0.12.tgz",
+			"integrity": "sha512-HAcadga3Qjt1Cqy+qXEW6zjaCs8uJGdGQrqltzl3OjiK4epGZRdvSzTe63P+t/3z+D2wG+ffEPn0GVcDozmN1w==",
+			"dependencies": {
+				"@walletconnect/jsonrpc-utils": "^1.0.6",
+				"@walletconnect/safe-json": "^1.0.2",
+				"events": "^3.3.0",
+				"tslib": "1.14.1",
+				"ws": "^7.5.1"
+			}
+		},
+		"node_modules/@walletconnect/jsonrpc-ws-connection/node_modules/tslib": {
+			"version": "1.14.1",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+			"integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+		},
+		"node_modules/@walletconnect/keyvaluestorage": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/@walletconnect/keyvaluestorage/-/keyvaluestorage-1.0.2.tgz",
+			"integrity": "sha512-U/nNG+VLWoPFdwwKx0oliT4ziKQCEoQ27L5Hhw8YOFGA2Po9A9pULUYNWhDgHkrb0gYDNt//X7wABcEWWBd3FQ==",
+			"dependencies": {
+				"safe-json-utils": "^1.1.1",
+				"tslib": "1.14.1"
+			},
+			"peerDependencies": {
+				"@react-native-async-storage/async-storage": "1.x",
+				"lokijs": "1.x"
+			},
+			"peerDependenciesMeta": {
+				"@react-native-async-storage/async-storage": {
+					"optional": true
+				},
+				"lokijs": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@walletconnect/keyvaluestorage/node_modules/tslib": {
+			"version": "1.14.1",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+			"integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+		},
+		"node_modules/@walletconnect/logger": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/@walletconnect/logger/-/logger-2.0.1.tgz",
+			"integrity": "sha512-SsTKdsgWm+oDTBeNE/zHxxr5eJfZmE9/5yp/Ku+zJtcTAjELb3DXueWkDXmE9h8uHIbJzIb5wj5lPdzyrjT6hQ==",
+			"dependencies": {
+				"pino": "7.11.0",
+				"tslib": "1.14.1"
+			}
+		},
+		"node_modules/@walletconnect/logger/node_modules/tslib": {
+			"version": "1.14.1",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+			"integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+		},
+		"node_modules/@walletconnect/relay-api": {
+			"version": "1.0.9",
+			"resolved": "https://registry.npmjs.org/@walletconnect/relay-api/-/relay-api-1.0.9.tgz",
+			"integrity": "sha512-Q3+rylJOqRkO1D9Su0DPE3mmznbAalYapJ9qmzDgK28mYF9alcP3UwG/og5V7l7CFOqzCLi7B8BvcBUrpDj0Rg==",
+			"dependencies": {
+				"@walletconnect/jsonrpc-types": "^1.0.2",
+				"tslib": "1.14.1"
+			}
+		},
+		"node_modules/@walletconnect/relay-api/node_modules/tslib": {
+			"version": "1.14.1",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+			"integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+		},
+		"node_modules/@walletconnect/relay-auth": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/@walletconnect/relay-auth/-/relay-auth-1.0.4.tgz",
+			"integrity": "sha512-kKJcS6+WxYq5kshpPaxGHdwf5y98ZwbfuS4EE/NkQzqrDFm5Cj+dP8LofzWvjrrLkZq7Afy7WrQMXdLy8Sx7HQ==",
+			"dependencies": {
+				"@stablelib/ed25519": "^1.0.2",
+				"@stablelib/random": "^1.0.1",
+				"@walletconnect/safe-json": "^1.0.1",
+				"@walletconnect/time": "^1.0.2",
+				"tslib": "1.14.1",
+				"uint8arrays": "^3.0.0"
+			}
+		},
+		"node_modules/@walletconnect/relay-auth/node_modules/tslib": {
+			"version": "1.14.1",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+			"integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+		},
+		"node_modules/@walletconnect/safe-json": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/@walletconnect/safe-json/-/safe-json-1.0.2.tgz",
+			"integrity": "sha512-Ogb7I27kZ3LPC3ibn8ldyUr5544t3/STow9+lzz7Sfo808YD7SBWk7SAsdBFlYgP2zDRy2hS3sKRcuSRM0OTmA==",
+			"dependencies": {
+				"tslib": "1.14.1"
+			}
+		},
+		"node_modules/@walletconnect/safe-json/node_modules/tslib": {
+			"version": "1.14.1",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+			"integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+		},
+		"node_modules/@walletconnect/sign-client": {
+			"version": "2.8.6",
+			"resolved": "https://registry.npmjs.org/@walletconnect/sign-client/-/sign-client-2.8.6.tgz",
+			"integrity": "sha512-rOFTKTHP7oJfXgYHX7+SdB8VbcsEE3ZFG/bMdmZboWaBim1mrY3vUyDdKrNr0VgI3AwBiEQezQDfKxBX0pMSQQ==",
+			"dependencies": {
+				"@walletconnect/core": "2.8.6",
+				"@walletconnect/events": "^1.0.1",
+				"@walletconnect/heartbeat": "1.2.1",
+				"@walletconnect/jsonrpc-utils": "1.0.8",
+				"@walletconnect/logger": "^2.0.1",
+				"@walletconnect/time": "^1.0.2",
+				"@walletconnect/types": "2.8.6",
+				"@walletconnect/utils": "2.8.6",
+				"events": "^3.3.0"
+			}
+		},
+		"node_modules/@walletconnect/time": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/@walletconnect/time/-/time-1.0.2.tgz",
+			"integrity": "sha512-uzdd9woDcJ1AaBZRhqy5rNC9laqWGErfc4dxA9a87mPdKOgWMD85mcFo9dIYIts/Jwocfwn07EC6EzclKubk/g==",
+			"dependencies": {
+				"tslib": "1.14.1"
+			}
+		},
+		"node_modules/@walletconnect/time/node_modules/tslib": {
+			"version": "1.14.1",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+			"integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+		},
+		"node_modules/@walletconnect/types": {
+			"version": "2.8.6",
+			"resolved": "https://registry.npmjs.org/@walletconnect/types/-/types-2.8.6.tgz",
+			"integrity": "sha512-Z/PFa3W1XdxeTcCtdR6lUsFgZfU/69wWJBPyclPwn7cu1+eriuCr6XZXQpJjib3flU+HnwHiXeUuqZaheehPxw==",
+			"dependencies": {
+				"@walletconnect/events": "^1.0.1",
+				"@walletconnect/heartbeat": "1.2.1",
+				"@walletconnect/jsonrpc-types": "1.0.3",
+				"@walletconnect/keyvaluestorage": "^1.0.2",
+				"@walletconnect/logger": "^2.0.1",
+				"events": "^3.3.0"
+			}
+		},
+		"node_modules/@walletconnect/utils": {
+			"version": "2.8.6",
+			"resolved": "https://registry.npmjs.org/@walletconnect/utils/-/utils-2.8.6.tgz",
+			"integrity": "sha512-wcy6e5+COYo7tfNnW8YqidnATdJDIW6vDiWWE7A1F78Sl/VflkaevB9cIgyn8eLdxC1SxXgGoeC2oLP90nnHJg==",
+			"dependencies": {
+				"@stablelib/chacha20poly1305": "1.0.1",
+				"@stablelib/hkdf": "1.0.1",
+				"@stablelib/random": "^1.0.2",
+				"@stablelib/sha256": "1.0.1",
+				"@stablelib/x25519": "^1.0.3",
+				"@walletconnect/relay-api": "^1.0.9",
+				"@walletconnect/safe-json": "^1.0.2",
+				"@walletconnect/time": "^1.0.2",
+				"@walletconnect/types": "2.8.6",
+				"@walletconnect/window-getters": "^1.0.1",
+				"@walletconnect/window-metadata": "^1.0.1",
+				"detect-browser": "5.3.0",
+				"query-string": "7.1.3",
+				"uint8arrays": "^3.1.0"
+			}
+		},
+		"node_modules/@walletconnect/window-getters": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@walletconnect/window-getters/-/window-getters-1.0.1.tgz",
+			"integrity": "sha512-vHp+HqzGxORPAN8gY03qnbTMnhqIwjeRJNOMOAzePRg4xVEEE2WvYsI9G2NMjOknA8hnuYbU3/hwLcKbjhc8+Q==",
+			"dependencies": {
+				"tslib": "1.14.1"
+			}
+		},
+		"node_modules/@walletconnect/window-getters/node_modules/tslib": {
+			"version": "1.14.1",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+			"integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+		},
+		"node_modules/@walletconnect/window-metadata": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@walletconnect/window-metadata/-/window-metadata-1.0.1.tgz",
+			"integrity": "sha512-9koTqyGrM2cqFRW517BPY/iEtUDx2r1+Pwwu5m7sJ7ka79wi3EyqhqcICk/yDmv6jAS1rjKgTKXlEhanYjijcA==",
+			"dependencies": {
+				"@walletconnect/window-getters": "^1.0.1",
+				"tslib": "1.14.1"
+			}
+		},
+		"node_modules/@walletconnect/window-metadata/node_modules/tslib": {
+			"version": "1.14.1",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+			"integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+		},
 		"node_modules/acorn": {
 			"version": "8.9.0",
 			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.9.0.tgz",
 			"integrity": "sha512-jaVNAFBHNLXspO543WnNNPZFRtavh3skAkITqD0/2aeMkKZTN+254PyhwxFYrk3vQ1xfY+2wbesJMs/JC8/PwQ==",
-			"dev": true,
 			"bin": {
 				"acorn": "bin/acorn"
 			},
@@ -966,7 +1943,6 @@
 			"version": "5.3.0",
 			"resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
 			"integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
-			"dev": true,
 			"dependencies": {
 				"dequal": "^2.0.3"
 			}
@@ -980,11 +1956,26 @@
 				"node": ">=8"
 			}
 		},
+		"node_modules/atomic-sleep": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/atomic-sleep/-/atomic-sleep-1.0.0.tgz",
+			"integrity": "sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ==",
+			"engines": {
+				"node": ">=8.0.0"
+			}
+		},
+		"node_modules/axios": {
+			"version": "0.24.0",
+			"resolved": "https://registry.npmjs.org/axios/-/axios-0.24.0.tgz",
+			"integrity": "sha512-Q6cWsys88HoPgAaFAVUb0WpPk0O8iTeisR9IMqy9G8AbO4NlpVknrnQS03zzF9PGAWgO3cgletO3VjV/P7VztA==",
+			"dependencies": {
+				"follow-redirects": "^1.14.4"
+			}
+		},
 		"node_modules/axobject-query": {
 			"version": "3.2.1",
 			"resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-3.2.1.tgz",
 			"integrity": "sha512-jsyHu61e6N4Vbz/v18DHwWYKK0bSWLqn47eeDSKPB7m8tqMHF9YJ+mhIk2lVteyZrY8tnSj/jHOv4YiTCuCJgg==",
-			"dev": true,
 			"dependencies": {
 				"dequal": "^2.0.3"
 			}
@@ -995,6 +1986,41 @@
 			"integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
 			"dev": true
 		},
+		"node_modules/base-x": {
+			"version": "3.0.9",
+			"resolved": "https://registry.npmjs.org/base-x/-/base-x-3.0.9.tgz",
+			"integrity": "sha512-H7JU6iBHTal1gp56aKoaa//YUxEaAOUiydvrV/pILqIHXTtqxSkATOnDA2u+jZ/61sD+L/412+7kzXRtWukhpQ==",
+			"dependencies": {
+				"safe-buffer": "^5.0.1"
+			}
+		},
+		"node_modules/base64-js": {
+			"version": "1.5.1",
+			"resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+			"integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/feross"
+				},
+				{
+					"type": "patreon",
+					"url": "https://www.patreon.com/feross"
+				},
+				{
+					"type": "consulting",
+					"url": "https://feross.org/support"
+				}
+			]
+		},
+		"node_modules/bignumber.js": {
+			"version": "9.1.1",
+			"resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.1.1.tgz",
+			"integrity": "sha512-pHm4LsMJ6lzgNGVfZHjMoO8sdoRhOzOH4MLmY65Jg70bpxCKu5iOHNJyfF6OyvYw7t8Fpf35RuzUyqnQsj8Vig==",
+			"engines": {
+				"node": "*"
+			}
+		},
 		"node_modules/binary-extensions": {
 			"version": "2.2.0",
 			"resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
@@ -1003,6 +2029,16 @@
 			"engines": {
 				"node": ">=8"
 			}
+		},
+		"node_modules/blakejs": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/blakejs/-/blakejs-1.2.1.tgz",
+			"integrity": "sha512-QXUSXI3QVc/gJME0dBpXrag1kbzOqCjCX8/b54ntNyW6sjtoqxqRk3LTmXzaJoh71zMsDCjM+47jS7XiwN/+fQ=="
+		},
+		"node_modules/bn.js": {
+			"version": "4.12.0",
+			"resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
+			"integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA=="
 		},
 		"node_modules/brace-expansion": {
 			"version": "1.1.11",
@@ -1024,6 +2060,52 @@
 			},
 			"engines": {
 				"node": ">=8"
+			}
+		},
+		"node_modules/brorand": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz",
+			"integrity": "sha512-cKV8tMCEpQs4hK/ik71d6LrPOnpkpGBR0wzxqr68g2m/LB2GxVYQroAjMJZRVM1Y4BCjCKc3vAamxSzOY2RP+w=="
+		},
+		"node_modules/bs58": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/bs58/-/bs58-4.0.1.tgz",
+			"integrity": "sha512-Ok3Wdf5vOIlBrgCvTq96gBkJw+JUEzdBgyaza5HLtPm7yTHkjRy8+JzNyHF7BHa0bNWOQIp3m5YF0nnFcOIKLw==",
+			"dependencies": {
+				"base-x": "^3.0.2"
+			}
+		},
+		"node_modules/bs58check": {
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/bs58check/-/bs58check-2.1.2.tgz",
+			"integrity": "sha512-0TS1jicxdU09dwJMNZtVAfzPi6Q6QeN0pM1Fkzrjn+XYHvzMKPU3pHVpva+769iNVSfIYWf7LJ6WR+BuuMf8cA==",
+			"dependencies": {
+				"bs58": "^4.0.0",
+				"create-hash": "^1.1.0",
+				"safe-buffer": "^5.1.2"
+			}
+		},
+		"node_modules/buffer": {
+			"version": "6.0.3",
+			"resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+			"integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/feross"
+				},
+				{
+					"type": "patreon",
+					"url": "https://www.patreon.com/feross"
+				},
+				{
+					"type": "consulting",
+					"url": "https://feross.org/support"
+				}
+			],
+			"dependencies": {
+				"base64-js": "^1.3.1",
+				"ieee754": "^1.2.1"
 			}
 		},
 		"node_modules/buffer-crc32": {
@@ -1111,11 +2193,19 @@
 				"node": ">= 6"
 			}
 		},
+		"node_modules/cipher-base": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.4.tgz",
+			"integrity": "sha512-Kkht5ye6ZGmwv40uUDZztayT2ThLQGfnj/T71N/XzeZeo3nf8foyW7zGTsPYkEya3m5f3cAypH+qe7YOrM1U2Q==",
+			"dependencies": {
+				"inherits": "^2.0.1",
+				"safe-buffer": "^5.0.1"
+			}
+		},
 		"node_modules/code-red": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/code-red/-/code-red-1.0.3.tgz",
 			"integrity": "sha512-kVwJELqiILQyG5aeuyKFbdsI1fmQy1Cmf7dQ8eGmVuJoaRVdwey7WaMknr2ZFeVSYSKT0rExsa8EGw0aoI/1QQ==",
-			"dev": true,
 			"dependencies": {
 				"@jridgewell/sourcemap-codec": "^1.4.14",
 				"@types/estree": "^1.0.0",
@@ -1157,6 +2247,18 @@
 				"node": ">= 0.6"
 			}
 		},
+		"node_modules/create-hash": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz",
+			"integrity": "sha512-z00bCGNHDG8mHAkP7CtT1qVu+bFQUPjYq/4Iv3C3kWjTFV10zIjfSoeqXo9Asws8gwSHDGj/hl2u4OGIjapeCg==",
+			"dependencies": {
+				"cipher-base": "^1.0.1",
+				"inherits": "^2.0.1",
+				"md5.js": "^1.3.4",
+				"ripemd160": "^2.0.1",
+				"sha.js": "^2.4.0"
+			}
+		},
 		"node_modules/cross-spawn": {
 			"version": "7.0.3",
 			"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
@@ -1175,7 +2277,6 @@
 			"version": "2.3.1",
 			"resolved": "https://registry.npmjs.org/css-tree/-/css-tree-2.3.1.tgz",
 			"integrity": "sha512-6Fv1DV/TYw//QF5IzQdqsNDjx/wc8TrMBZsqjL9eW01tWb7R7k/mq+/VXfJCl7SoD5emsJop9cOByJZfs8hYIw==",
-			"dev": true,
 			"dependencies": {
 				"mdn-data": "2.0.30",
 				"source-map-js": "^1.0.1"
@@ -1196,6 +2297,11 @@
 				"node": ">=4"
 			}
 		},
+		"node_modules/csstype": {
+			"version": "3.1.2",
+			"resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.2.tgz",
+			"integrity": "sha512-I7K1Uu0MBPzaFKg4nI5Q7Vs2t+3gWWW648spaF+Rg7pI9ds18Ugn+lvg4SHczUdKlHI5LWBXyqfS8+DufyBsgQ=="
+		},
 		"node_modules/debug": {
 			"version": "4.3.4",
 			"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
@@ -1211,6 +2317,14 @@
 				"supports-color": {
 					"optional": true
 				}
+			}
+		},
+		"node_modules/decode-uri-component": {
+			"version": "0.2.2",
+			"resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.2.tgz",
+			"integrity": "sha512-FqUYQ+8o158GyGTrMFJms9qh3CqTKvAqgqsTnkLI8sKu0028orqBhxNMFkFen0zGyg6epACD32pjVk58ngIErQ==",
+			"engines": {
+				"node": ">=0.10"
 			}
 		},
 		"node_modules/deep-is": {
@@ -1232,10 +2346,14 @@
 			"version": "2.0.3",
 			"resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
 			"integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
-			"dev": true,
 			"engines": {
 				"node": ">=6"
 			}
+		},
+		"node_modules/detect-browser": {
+			"version": "5.3.0",
+			"resolved": "https://registry.npmjs.org/detect-browser/-/detect-browser-5.3.0.tgz",
+			"integrity": "sha512-53rsFbGdwMwlF7qvCt0ypLM5V5/Mbl0szB7GPN8y9NCcbknYOeVVXdrXEq+90IwAfrrzt6Hd+u2E2ntakICU8w=="
 		},
 		"node_modules/detect-indent": {
 			"version": "6.1.0",
@@ -1276,6 +2394,39 @@
 				"node": ">=6.0.0"
 			}
 		},
+		"node_modules/duplexify": {
+			"version": "4.1.2",
+			"resolved": "https://registry.npmjs.org/duplexify/-/duplexify-4.1.2.tgz",
+			"integrity": "sha512-fz3OjcNCHmRP12MJoZMPglx8m4rrFP8rovnk4vT8Fs+aonZoCwGg10dSsQsfP/E62eZcPTMSMP6686fu9Qlqtw==",
+			"dependencies": {
+				"end-of-stream": "^1.4.1",
+				"inherits": "^2.0.3",
+				"readable-stream": "^3.1.1",
+				"stream-shift": "^1.0.0"
+			}
+		},
+		"node_modules/elliptic": {
+			"version": "6.5.4",
+			"resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.4.tgz",
+			"integrity": "sha512-iLhC6ULemrljPZb+QutR5TQGB+pdW6KGD5RSegS+8sorOZT+rdQFbsQFJgvN3eRqNALqJer4oQ16YvJHlU8hzQ==",
+			"dependencies": {
+				"bn.js": "^4.11.9",
+				"brorand": "^1.1.0",
+				"hash.js": "^1.0.0",
+				"hmac-drbg": "^1.0.1",
+				"inherits": "^2.0.4",
+				"minimalistic-assert": "^1.0.1",
+				"minimalistic-crypto-utils": "^1.0.1"
+			}
+		},
+		"node_modules/end-of-stream": {
+			"version": "1.4.4",
+			"resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
+			"integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
+			"dependencies": {
+				"once": "^1.4.0"
+			}
+		},
 		"node_modules/es6-promise": {
 			"version": "3.3.1",
 			"resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-3.3.1.tgz",
@@ -1286,7 +2437,6 @@
 			"version": "0.17.19",
 			"resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.17.19.tgz",
 			"integrity": "sha512-XQ0jAPFkK/u3LcVRcvVHQcTIqD6E2H1fvZMA5dQPSOWb3suUbWbfbRf94pjc0bNzRYLfIrDRQXr7X+LHIm5oHw==",
-			"dev": true,
 			"hasInstallScript": true,
 			"bin": {
 				"esbuild": "bin/esbuild"
@@ -1561,7 +2711,6 @@
 			"version": "3.0.3",
 			"resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
 			"integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
-			"dev": true,
 			"dependencies": {
 				"@types/estree": "^1.0.0"
 			}
@@ -1573,6 +2722,14 @@
 			"dev": true,
 			"engines": {
 				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/events": {
+			"version": "3.3.0",
+			"resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
+			"integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
+			"engines": {
+				"node": ">=0.8.x"
 			}
 		},
 		"node_modules/fast-deep-equal": {
@@ -1612,14 +2769,21 @@
 		"node_modules/fast-json-stable-stringify": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
-			"integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
-			"dev": true
+			"integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="
 		},
 		"node_modules/fast-levenshtein": {
 			"version": "2.0.6",
 			"resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
 			"integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
 			"dev": true
+		},
+		"node_modules/fast-redact": {
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/fast-redact/-/fast-redact-3.2.0.tgz",
+			"integrity": "sha512-zaTadChr+NekyzallAMXATXLOR8MNx3zqpZ0MUF2aGf4EathnG0f32VLODNlY8IuGY3HoRO2L6/6fSzNsLaHIw==",
+			"engines": {
+				"node": ">=6"
+			}
 		},
 		"node_modules/fastq": {
 			"version": "1.15.0",
@@ -1652,6 +2816,14 @@
 			},
 			"engines": {
 				"node": ">=8"
+			}
+		},
+		"node_modules/filter-obj": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/filter-obj/-/filter-obj-1.1.0.tgz",
+			"integrity": "sha512-8rXg1ZnX7xzy2NGDVkBVaAy+lSlPNwad13BtgSlLuxfIslyt5Vg64U7tFcCt4WS1R0hvtnQybT/IyCkGZ3DpXQ==",
+			"engines": {
+				"node": ">=0.10.0"
 			}
 		},
 		"node_modules/find-up": {
@@ -1688,6 +2860,25 @@
 			"resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.7.tgz",
 			"integrity": "sha512-5nqDSxl8nn5BSNxyR3n4I6eDmbolI6WT+QqR547RwxQapgjQBmtktdP+HTBb/a/zLsbzERTONyUB5pefh5TtjQ==",
 			"dev": true
+		},
+		"node_modules/follow-redirects": {
+			"version": "1.15.2",
+			"resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.2.tgz",
+			"integrity": "sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA==",
+			"funding": [
+				{
+					"type": "individual",
+					"url": "https://github.com/sponsors/RubenVerborgh"
+				}
+			],
+			"engines": {
+				"node": ">=4.0"
+			},
+			"peerDependenciesMeta": {
+				"debug": {
+					"optional": true
+				}
+			}
 		},
 		"node_modules/fs.realpath": {
 			"version": "1.0.0",
@@ -1797,6 +2988,57 @@
 				"node": ">=8"
 			}
 		},
+		"node_modules/hash-base": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/hash-base/-/hash-base-3.1.0.tgz",
+			"integrity": "sha512-1nmYp/rhMDiE7AYkDw+lLwlAzz0AntGIe51F3RfFfEqyQ3feY2eI/NcwC6umIQVOASPMsWJLJScWKSSvzL9IVA==",
+			"dependencies": {
+				"inherits": "^2.0.4",
+				"readable-stream": "^3.6.0",
+				"safe-buffer": "^5.2.0"
+			},
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/hash.js": {
+			"version": "1.1.7",
+			"resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.7.tgz",
+			"integrity": "sha512-taOaskGt4z4SOANNseOviYDvjEJinIkRgmp7LbKP2YTTmVxWBl87s/uzK9r+44BclBSp2X7K1hqeNfz9JbBeXA==",
+			"dependencies": {
+				"inherits": "^2.0.3",
+				"minimalistic-assert": "^1.0.1"
+			}
+		},
+		"node_modules/hmac-drbg": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
+			"integrity": "sha512-Tti3gMqLdZfhOQY1Mzf/AanLiqh1WTiJgEj26ZuYQ9fbkLomzGchCws4FyrSd4VkpBfiNhaE1On+lOz894jvXg==",
+			"dependencies": {
+				"hash.js": "^1.0.3",
+				"minimalistic-assert": "^1.0.0",
+				"minimalistic-crypto-utils": "^1.0.1"
+			}
+		},
+		"node_modules/ieee754": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+			"integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/feross"
+				},
+				{
+					"type": "patreon",
+					"url": "https://www.patreon.com/feross"
+				},
+				{
+					"type": "consulting",
+					"url": "https://feross.org/support"
+				}
+			]
+		},
 		"node_modules/ignore": {
 			"version": "5.2.4",
 			"resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.4.tgz",
@@ -1854,8 +3096,7 @@
 		"node_modules/inherits": {
 			"version": "2.0.4",
 			"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-			"integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-			"dev": true
+			"integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
 		},
 		"node_modules/is-binary-path": {
 			"version": "2.1.0",
@@ -1912,7 +3153,6 @@
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/is-reference/-/is-reference-3.0.1.tgz",
 			"integrity": "sha512-baJJdQLiYaJdvFbJqXrcGv3WU3QCzBlUcI5QhbesIm6/xPsvmO+2CDoi/GMOFBQEQm+PXkwOPrp9KK5ozZsp2w==",
-			"dev": true,
 			"dependencies": {
 				"@types/estree": "*"
 			}
@@ -1946,6 +3186,11 @@
 			"resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
 			"integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
 			"dev": true
+		},
+		"node_modules/keyvaluestorage-interface": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/keyvaluestorage-interface/-/keyvaluestorage-interface-1.0.0.tgz",
+			"integrity": "sha512-8t6Q3TclQ4uZynJY9IGr2+SsIGwK9JHcO6ootkHCGA0CrQCRy+VkouYNO2xicET6b9al7QKzpebNow+gkpCL8g=="
 		},
 		"node_modules/kleur": {
 			"version": "4.1.5",
@@ -1987,8 +3232,7 @@
 		"node_modules/locate-character": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/locate-character/-/locate-character-3.0.0.tgz",
-			"integrity": "sha512-SW13ws7BjaeJ6p7Q6CO2nchbYEc3X3J6WrmTTDto7yMPqVSZTUyY5Tjbid+Ab8gLnATtygYtiDIJGQRRn2ZOiA==",
-			"dev": true
+			"integrity": "sha512-SW13ws7BjaeJ6p7Q6CO2nchbYEc3X3J6WrmTTDto7yMPqVSZTUyY5Tjbid+Ab8gLnATtygYtiDIJGQRRn2ZOiA=="
 		},
 		"node_modules/locate-path": {
 			"version": "6.0.0",
@@ -2004,6 +3248,11 @@
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
+		},
+		"node_modules/lodash.isequal": {
+			"version": "4.5.0",
+			"resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
+			"integrity": "sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ=="
 		},
 		"node_modules/lodash.merge": {
 			"version": "4.6.2",
@@ -2027,7 +3276,6 @@
 			"version": "0.30.0",
 			"resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.0.tgz",
 			"integrity": "sha512-LA+31JYDJLs82r2ScLrlz1GjSgu66ZV518eyWT+S8VhyQn/JL0u9MeBOvQMGYiPk1DBiSN9DDMOcXvigJZaViQ==",
-			"dev": true,
 			"dependencies": {
 				"@jridgewell/sourcemap-codec": "^1.4.13"
 			},
@@ -2035,11 +3283,20 @@
 				"node": ">=12"
 			}
 		},
+		"node_modules/md5.js": {
+			"version": "1.3.5",
+			"resolved": "https://registry.npmjs.org/md5.js/-/md5.js-1.3.5.tgz",
+			"integrity": "sha512-xitP+WxNPcTTOgnTJcrhM0xvdPepipPSf3I8EIpGKeFLjt3PlJLIDG3u8EX53ZIubkb+5U2+3rELYpEhHhzdkg==",
+			"dependencies": {
+				"hash-base": "^3.0.0",
+				"inherits": "^2.0.1",
+				"safe-buffer": "^5.1.2"
+			}
+		},
 		"node_modules/mdn-data": {
 			"version": "2.0.30",
 			"resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.30.tgz",
-			"integrity": "sha512-GaqWWShW4kv/G9IEucWScBx9G1/vsFZZJUO+tD26M8J8z3Kw5RDQjaoZe03YAClgeS/SWPOcb4nkFBTEi5DUEA==",
-			"dev": true
+			"integrity": "sha512-GaqWWShW4kv/G9IEucWScBx9G1/vsFZZJUO+tD26M8J8z3Kw5RDQjaoZe03YAClgeS/SWPOcb4nkFBTEi5DUEA=="
 		},
 		"node_modules/merge2": {
 			"version": "1.4.1",
@@ -2083,6 +3340,16 @@
 			"engines": {
 				"node": ">=4"
 			}
+		},
+		"node_modules/minimalistic-assert": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
+			"integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A=="
+		},
+		"node_modules/minimalistic-crypto-utils": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz",
+			"integrity": "sha512-JIYlbt6g8i5jKfJ3xz7rF0LXmv2TkDxBLUkiBeZ7bAx4GnnNMr8xFpGnOxn6GhTEHx3SjRrZEoU+j04prX1ktg=="
 		},
 		"node_modules/minimatch": {
 			"version": "3.1.2",
@@ -2141,6 +3408,11 @@
 			"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
 			"dev": true
 		},
+		"node_modules/multiformats": {
+			"version": "9.9.0",
+			"resolved": "https://registry.npmjs.org/multiformats/-/multiformats-9.9.0.tgz",
+			"integrity": "sha512-HoMUjhH9T8DDBNT+6xzkrd9ga/XiBI4xLr58LJACwK6G3HTOPeMz4nB4KJs33L2BelrIJa7P0VuNaVF3hMYfjg=="
+		},
 		"node_modules/nanoid": {
 			"version": "3.3.6",
 			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.6.tgz",
@@ -2180,11 +3452,15 @@
 				"node": ">=0.10.0"
 			}
 		},
+		"node_modules/on-exit-leak-free": {
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/on-exit-leak-free/-/on-exit-leak-free-0.2.0.tgz",
+			"integrity": "sha512-dqaz3u44QbRXQooZLTUKU41ZrzYrcvLISVgbrzbyCMxpmSLJvZ3ZamIJIZ29P6OhZIkNIQKosdeM6t1LYbA9hg=="
+		},
 		"node_modules/once": {
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
 			"integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
-			"dev": true,
 			"dependencies": {
 				"wrappy": "1"
 			}
@@ -2288,7 +3564,6 @@
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/periscopic/-/periscopic-3.1.0.tgz",
 			"integrity": "sha512-vKiQ8RRtkl9P+r/+oefh25C3fhybptkHKCZSPlcXiJux2tJF55GnEj3BVn4A5gKfq9NWWXXrxkHBwVPUfH0opw==",
-			"dev": true,
 			"dependencies": {
 				"@types/estree": "^1.0.0",
 				"estree-walker": "^3.0.0",
@@ -2312,6 +3587,41 @@
 			"funding": {
 				"url": "https://github.com/sponsors/jonschlinkert"
 			}
+		},
+		"node_modules/pino": {
+			"version": "7.11.0",
+			"resolved": "https://registry.npmjs.org/pino/-/pino-7.11.0.tgz",
+			"integrity": "sha512-dMACeu63HtRLmCG8VKdy4cShCPKaYDR4youZqoSWLxl5Gu99HUw8bw75thbPv9Nip+H+QYX8o3ZJbTdVZZ2TVg==",
+			"dependencies": {
+				"atomic-sleep": "^1.0.0",
+				"fast-redact": "^3.0.0",
+				"on-exit-leak-free": "^0.2.0",
+				"pino-abstract-transport": "v0.5.0",
+				"pino-std-serializers": "^4.0.0",
+				"process-warning": "^1.0.0",
+				"quick-format-unescaped": "^4.0.3",
+				"real-require": "^0.1.0",
+				"safe-stable-stringify": "^2.1.0",
+				"sonic-boom": "^2.2.1",
+				"thread-stream": "^0.15.1"
+			},
+			"bin": {
+				"pino": "bin.js"
+			}
+		},
+		"node_modules/pino-abstract-transport": {
+			"version": "0.5.0",
+			"resolved": "https://registry.npmjs.org/pino-abstract-transport/-/pino-abstract-transport-0.5.0.tgz",
+			"integrity": "sha512-+KAgmVeqXYbTtU2FScx1XS3kNyfZ5TrXY07V96QnUSFqo2gAqlvmaxH67Lj7SWazqsMabf+58ctdTcBgnOLUOQ==",
+			"dependencies": {
+				"duplexify": "^4.1.2",
+				"split2": "^4.0.0"
+			}
+		},
+		"node_modules/pino-std-serializers": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-4.0.0.tgz",
+			"integrity": "sha512-cK0pekc1Kjy5w9V2/n+8MkZwusa6EyyxfeQCB799CQRhRt/CqYKiWs5adeu8Shve2ZNffvfC/7J64A2PJo1W/Q=="
 		},
 		"node_modules/postcss": {
 			"version": "8.4.24",
@@ -2455,6 +3765,11 @@
 				"svelte": "^3.2.0 || ^4.0.0-next.0"
 			}
 		},
+		"node_modules/process-warning": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/process-warning/-/process-warning-1.0.0.tgz",
+			"integrity": "sha512-du4wfLyj4yCZq1VupnVSZmRsPJsNuxoDQFdCFHLaYiEbFBD7QE0a+I4D7hOxrVnh78QE/YipFAj9lXHiXocV+Q=="
+		},
 		"node_modules/punycode": {
 			"version": "2.3.0",
 			"resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.0.tgz",
@@ -2462,6 +3777,31 @@
 			"dev": true,
 			"engines": {
 				"node": ">=6"
+			}
+		},
+		"node_modules/qrcode-svg": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/qrcode-svg/-/qrcode-svg-1.1.0.tgz",
+			"integrity": "sha512-XyQCIXux1zEIA3NPb0AeR8UMYvXZzWEhgdBgBjH9gO7M48H9uoHzviNz8pXw3UzrAcxRRRn9gxHewAVK7bn9qw==",
+			"bin": {
+				"qrcode-svg": "bin/qrcode-svg.js"
+			}
+		},
+		"node_modules/query-string": {
+			"version": "7.1.3",
+			"resolved": "https://registry.npmjs.org/query-string/-/query-string-7.1.3.tgz",
+			"integrity": "sha512-hh2WYhq4fi8+b+/2Kg9CEge4fDPvHS534aOOvOZeQ3+Vf2mCFsaFBYj0i+iXcAq6I9Vzp5fjMFBlONvayDC1qg==",
+			"dependencies": {
+				"decode-uri-component": "^0.2.2",
+				"filter-obj": "^1.1.0",
+				"split-on-first": "^1.0.0",
+				"strict-uri-encode": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=6"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/queue-microtask": {
@@ -2484,6 +3824,24 @@
 				}
 			]
 		},
+		"node_modules/quick-format-unescaped": {
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/quick-format-unescaped/-/quick-format-unescaped-4.0.4.tgz",
+			"integrity": "sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg=="
+		},
+		"node_modules/readable-stream": {
+			"version": "3.6.2",
+			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+			"integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+			"dependencies": {
+				"inherits": "^2.0.3",
+				"string_decoder": "^1.1.1",
+				"util-deprecate": "^1.0.1"
+			},
+			"engines": {
+				"node": ">= 6"
+			}
+		},
 		"node_modules/readdirp": {
 			"version": "3.6.0",
 			"resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
@@ -2494,6 +3852,14 @@
 			},
 			"engines": {
 				"node": ">=8.10.0"
+			}
+		},
+		"node_modules/real-require": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/real-require/-/real-require-0.1.0.tgz",
+			"integrity": "sha512-r/H9MzAWtrv8aSVjPCMFpDMl5q66GqtmmRkRjpHTsp4zBAa+snZyiQNlMONiUmEJcsnaw0wCauJ2GWODr/aFkg==",
+			"engines": {
+				"node": ">= 12.13.0"
 			}
 		},
 		"node_modules/resolve-from": {
@@ -2528,6 +3894,15 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/ripemd160": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-2.0.2.tgz",
+			"integrity": "sha512-ii4iagi25WusVoiC4B4lq7pbXfAp3D9v5CwfkY33vffw2+pkDjY1D8GaN7spsxvCSx8dkPqOZCEZyfxcmJG2IA==",
+			"dependencies": {
+				"hash-base": "^3.0.0",
+				"inherits": "^2.0.1"
 			}
 		},
 		"node_modules/rollup": {
@@ -2569,6 +3944,22 @@
 				"queue-microtask": "^1.2.2"
 			}
 		},
+		"node_modules/rxjs": {
+			"version": "6.6.7",
+			"resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.6.7.tgz",
+			"integrity": "sha512-hTdwr+7yYNIT5n4AMYp85KA6yw2Va0FLa3Rguvbpa4W3I5xynaBZo41cM3XM+4Q6fRMj3sBYIR1VAmZMXYJvRQ==",
+			"dependencies": {
+				"tslib": "^1.9.0"
+			},
+			"engines": {
+				"npm": ">=2.0.0"
+			}
+		},
+		"node_modules/rxjs/node_modules/tslib": {
+			"version": "1.14.1",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+			"integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+		},
 		"node_modules/sade": {
 			"version": "1.8.1",
 			"resolved": "https://registry.npmjs.org/sade/-/sade-1.8.1.tgz",
@@ -2579,6 +3970,38 @@
 			},
 			"engines": {
 				"node": ">=6"
+			}
+		},
+		"node_modules/safe-buffer": {
+			"version": "5.2.1",
+			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+			"integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/feross"
+				},
+				{
+					"type": "patreon",
+					"url": "https://www.patreon.com/feross"
+				},
+				{
+					"type": "consulting",
+					"url": "https://feross.org/support"
+				}
+			]
+		},
+		"node_modules/safe-json-utils": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/safe-json-utils/-/safe-json-utils-1.1.1.tgz",
+			"integrity": "sha512-SAJWGKDs50tAbiDXLf89PDwt9XYkWyANFWVzn4dTXl5QyI8t2o/bW5/OJl3lvc2WVU4MEpTo9Yz5NVFNsp+OJQ=="
+		},
+		"node_modules/safe-stable-stringify": {
+			"version": "2.4.3",
+			"resolved": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-2.4.3.tgz",
+			"integrity": "sha512-e2bDA2WJT0wxseVd4lsDP4+3ONX6HpMXQa1ZhFQ7SU+GjvORCmShbCMltrtIDfkYhVHrOcPtj+KhmDBdPdZD1g==",
+			"engines": {
+				"node": ">=10"
 			}
 		},
 		"node_modules/sander": {
@@ -2620,11 +4043,31 @@
 				"node": ">=10"
 			}
 		},
+		"node_modules/seroval": {
+			"version": "0.5.1",
+			"resolved": "https://registry.npmjs.org/seroval/-/seroval-0.5.1.tgz",
+			"integrity": "sha512-ZfhQVB59hmIauJG5Ydynupy8KHyr5imGNtdDhbZG68Ufh1Ynkv9KOYOAABf71oVbQxJ8VkWnMHAjEHE7fWkH5g==",
+			"engines": {
+				"node": ">=10"
+			}
+		},
 		"node_modules/set-cookie-parser": {
 			"version": "2.6.0",
 			"resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.6.0.tgz",
 			"integrity": "sha512-RVnVQxTXuerk653XfuliOxBP81Sf0+qfQE73LIYKcyMYHG94AuH0kgrQpRDuTZnSmjpysHmzxJXKNfa6PjFhyQ==",
 			"dev": true
+		},
+		"node_modules/sha.js": {
+			"version": "2.4.11",
+			"resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
+			"integrity": "sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==",
+			"dependencies": {
+				"inherits": "^2.0.1",
+				"safe-buffer": "^5.0.1"
+			},
+			"bin": {
+				"sha.js": "bin.js"
+			}
 		},
 		"node_modules/shebang-command": {
 			"version": "2.0.0",
@@ -2670,6 +4113,23 @@
 				"node": ">=8"
 			}
 		},
+		"node_modules/solid-js": {
+			"version": "1.7.7",
+			"resolved": "https://registry.npmjs.org/solid-js/-/solid-js-1.7.7.tgz",
+			"integrity": "sha512-SPdYVke/Z6Za24PBTbULyQYPrhGO1ZbPany76atO2zF2dmYn2pCotbsw1JtlgWnr9dK2JbwPGnA3ODTGPLhZNw==",
+			"dependencies": {
+				"csstype": "^3.1.0",
+				"seroval": "^0.5.0"
+			}
+		},
+		"node_modules/sonic-boom": {
+			"version": "2.8.0",
+			"resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-2.8.0.tgz",
+			"integrity": "sha512-kuonw1YOYYNOve5iHdSahXPOK49GqwA+LZhI6Wz/l0rP57iKyXXIHaRagOBHAPmGwJC6od2Z9zgvZ5loSgMlVg==",
+			"dependencies": {
+				"atomic-sleep": "^1.0.0"
+			}
+		},
 		"node_modules/sorcery": {
 			"version": "0.11.0",
 			"resolved": "https://registry.npmjs.org/sorcery/-/sorcery-0.11.0.tgz",
@@ -2689,10 +4149,30 @@
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.0.2.tgz",
 			"integrity": "sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==",
-			"dev": true,
 			"engines": {
 				"node": ">=0.10.0"
 			}
+		},
+		"node_modules/split-on-first": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/split-on-first/-/split-on-first-1.1.0.tgz",
+			"integrity": "sha512-43ZssAJaMusuKWL8sKUBQXHWOpq8d6CfN/u1p4gUzfJkM05C8rxTmYrkIPTXapZpORA6LkkzcUulJ8FqA7Uudw==",
+			"engines": {
+				"node": ">=6"
+			}
+		},
+		"node_modules/split2": {
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
+			"integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==",
+			"engines": {
+				"node": ">= 10.x"
+			}
+		},
+		"node_modules/stream-shift": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.1.tgz",
+			"integrity": "sha512-AiisoFqQ0vbGcZgQPY1cdP2I76glaVA/RauYR4G4thNFgkTqr90yXTo4LYX60Jl+sIlPNHHdGSwo01AvbKUSVQ=="
 		},
 		"node_modules/streamsearch": {
 			"version": "1.1.0",
@@ -2701,6 +4181,22 @@
 			"dev": true,
 			"engines": {
 				"node": ">=10.0.0"
+			}
+		},
+		"node_modules/strict-uri-encode": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-2.0.0.tgz",
+			"integrity": "sha512-QwiXZgpRcKkhTj2Scnn++4PKtWsH0kpzZ62L2R6c/LUVYv7hVnZqcg2+sMuT6R7Jusu1vviK/MFsu6kNJfWlEQ==",
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/string_decoder": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+			"integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+			"dependencies": {
+				"safe-buffer": "~5.2.0"
 			}
 		},
 		"node_modules/strip-ansi": {
@@ -2755,7 +4251,6 @@
 			"version": "4.0.3",
 			"resolved": "https://registry.npmjs.org/svelte/-/svelte-4.0.3.tgz",
 			"integrity": "sha512-SSJZBR+Uca3Xa/R18/7IkkifDdz2Jfuq2eXMUphDhabDxQL6qR8QAUoEmrtYWhzeV0civoFw4Dcvo2yscysdeg==",
-			"dev": true,
 			"dependencies": {
 				"@ampproject/remapping": "^2.2.1",
 				"@jridgewell/sourcemap-codec": "^1.4.15",
@@ -2935,11 +4430,34 @@
 				"node": ">=12"
 			}
 		},
+		"node_modules/svelte-tezos": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/svelte-tezos/-/svelte-tezos-1.0.0.tgz",
+			"integrity": "sha512-3hFXywpHgCplSl397VjnjUQY0CjWVIlT18sMoErscKgTlgLDZ4V7xu96y1PubhyRxC9S0dyMOIzQar2U4Gki6Q==",
+			"dependencies": {
+				"@airgap/beacon-sdk": "^4.0.4",
+				"@esbuild-plugins/node-globals-polyfill": "^0.2.3",
+				"@taquito/beacon-wallet": "^17.0.0",
+				"@taquito/taquito": "^17.0.0",
+				"vite-compatible-readable-stream": "^3.6.1"
+			},
+			"peerDependencies": {
+				"svelte": "^4.0.0"
+			}
+		},
 		"node_modules/text-table": {
 			"version": "0.2.0",
 			"resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
 			"integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
 			"dev": true
+		},
+		"node_modules/thread-stream": {
+			"version": "0.15.2",
+			"resolved": "https://registry.npmjs.org/thread-stream/-/thread-stream-0.15.2.tgz",
+			"integrity": "sha512-UkEhKIg2pD+fjkHQKyJO3yoIvAP3N6RlNFt2dUhcS1FGvCD1cQa1M/PGknCLFIyZdtJOWQjejp7bdNqmN7zwdA==",
+			"dependencies": {
+				"real-require": "^0.1.0"
+			}
 		},
 		"node_modules/to-regex-range": {
 			"version": "5.0.1",
@@ -3013,6 +4531,25 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
+		"node_modules/typedarray-to-buffer": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/typedarray-to-buffer/-/typedarray-to-buffer-4.0.0.tgz",
+			"integrity": "sha512-6dOYeZfS3O9RtRD1caom0sMxgK59b27+IwoNy8RDPsmslSGOyU+mpTamlaIW7aNKi90ZQZ9DFaZL3YRoiSCULQ==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/feross"
+				},
+				{
+					"type": "patreon",
+					"url": "https://www.patreon.com/feross"
+				},
+				{
+					"type": "consulting",
+					"url": "https://feross.org/support"
+				}
+			]
+		},
 		"node_modules/typescript": {
 			"version": "5.1.6",
 			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.1.6.tgz",
@@ -3024,6 +4561,14 @@
 			},
 			"engines": {
 				"node": ">=14.17"
+			}
+		},
+		"node_modules/uint8arrays": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-3.1.1.tgz",
+			"integrity": "sha512-+QJa8QRnbdXVpHYjLoTpJIdCTiw9Ir62nocClWuXIq2JIh4Uta0cQsTSpFL678p2CN8B+XSApwcU+pQEqVpKWg==",
+			"dependencies": {
+				"multiformats": "^9.4.2"
 			}
 		},
 		"node_modules/undici": {
@@ -3050,8 +4595,7 @@
 		"node_modules/util-deprecate": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-			"integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
-			"dev": true
+			"integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
 		},
 		"node_modules/vite": {
 			"version": "4.3.9",
@@ -3101,6 +4645,19 @@
 				}
 			}
 		},
+		"node_modules/vite-compatible-readable-stream": {
+			"version": "3.6.1",
+			"resolved": "https://registry.npmjs.org/vite-compatible-readable-stream/-/vite-compatible-readable-stream-3.6.1.tgz",
+			"integrity": "sha512-t20zYkrSf868+j/p31cRIGN28Phrjm3nRSLR2fyc2tiWi4cZGVdv68yNlwnIINTkMTmPoMiSlc0OadaO7DXZaQ==",
+			"dependencies": {
+				"inherits": "^2.0.3",
+				"string_decoder": "^1.1.1",
+				"util-deprecate": "^1.0.1"
+			},
+			"engines": {
+				"node": ">= 6"
+			}
+		},
 		"node_modules/vitefu": {
 			"version": "0.2.4",
 			"resolved": "https://registry.npmjs.org/vitefu/-/vitefu-0.2.4.tgz",
@@ -3133,8 +4690,27 @@
 		"node_modules/wrappy": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-			"integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
-			"dev": true
+			"integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="
+		},
+		"node_modules/ws": {
+			"version": "7.5.9",
+			"resolved": "https://registry.npmjs.org/ws/-/ws-7.5.9.tgz",
+			"integrity": "sha512-F+P9Jil7UiSKSkppIiD94dN07AwvFixvLIj1Og1Rl9GGMuNipJnV9JzjD6XuqmAeiswGvUmNLjr5cFuXwNS77Q==",
+			"engines": {
+				"node": ">=8.3.0"
+			},
+			"peerDependencies": {
+				"bufferutil": "^4.0.1",
+				"utf-8-validate": "^5.0.2"
+			},
+			"peerDependenciesMeta": {
+				"bufferutil": {
+					"optional": true
+				},
+				"utf-8-validate": {
+					"optional": true
+				}
+			}
 		},
 		"node_modules/yallist": {
 			"version": "4.0.0",
@@ -3171,168 +4747,286 @@
 			"integrity": "sha512-1Yjs2SvM8TflER/OD3cOjhWWOZb58A2t7wpE2S9XfBYTiIl+XFhQG2bjy4Pu1I+EAlCNUzRDYDdFwFYUKvXcIA==",
 			"dev": true
 		},
+		"@airgap/beacon-blockchain-substrate": {
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/@airgap/beacon-blockchain-substrate/-/beacon-blockchain-substrate-4.0.4.tgz",
+			"integrity": "sha512-aKggXvGtm+k6CDXzjowN42xIjkK5Aj++PGEmKK4RBvGNhwcWhd4S/5B09zURbUVcstcav2LM6G41X0OaNX7BYA==",
+			"requires": {
+				"@airgap/beacon-types": "4.0.4",
+				"@airgap/beacon-ui": "4.0.4"
+			}
+		},
+		"@airgap/beacon-blockchain-tezos": {
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/@airgap/beacon-blockchain-tezos/-/beacon-blockchain-tezos-4.0.4.tgz",
+			"integrity": "sha512-1JkrSwhvtWdimAk3og48SMmw6BLa1lArtAwwiBJXszZeleQ3/35GPH0t2iJRkbx6xKRv/36zGi7muUaQ3Pgq1A==",
+			"requires": {
+				"@airgap/beacon-types": "4.0.4",
+				"@airgap/beacon-ui": "4.0.4"
+			}
+		},
+		"@airgap/beacon-core": {
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/@airgap/beacon-core/-/beacon-core-4.0.4.tgz",
+			"integrity": "sha512-A64Q894XrivcfHgYD+iUz4Q9ymRnTLHcj3OIuW69lKk7eoJBi0PgFSpNNdENRQ6FXjLc0LNSbh8U+hG1MkNvgA==",
+			"requires": {
+				"@airgap/beacon-types": "4.0.4",
+				"@airgap/beacon-utils": "4.0.4",
+				"@stablelib/ed25519": "^1.0.3",
+				"@stablelib/nacl": "^1.0.4",
+				"@stablelib/utf8": "^1.0.1",
+				"@stablelib/x25519-session": "^1.0.4",
+				"bs58check": "2.1.2"
+			}
+		},
+		"@airgap/beacon-dapp": {
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/@airgap/beacon-dapp/-/beacon-dapp-4.0.4.tgz",
+			"integrity": "sha512-b1GoYpbmFdE74OGtKhns4LzuPlnid1USCSRRjIGfLqzHoSF8WpoGegSVpVy3zK4+UMkR6Xv7p2hpYeH8aAqadg==",
+			"requires": {
+				"@airgap/beacon-core": "4.0.4",
+				"@airgap/beacon-transport-matrix": "4.0.4",
+				"@airgap/beacon-transport-postmessage": "4.0.4",
+				"@airgap/beacon-transport-walletconnect": "4.0.4",
+				"@airgap/beacon-ui": "4.0.4"
+			}
+		},
+		"@airgap/beacon-sdk": {
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/@airgap/beacon-sdk/-/beacon-sdk-4.0.4.tgz",
+			"integrity": "sha512-jM3e8PJW4NDfExTqrUkCoZEeJxEV5926AVHJXjloWhTTAxtDqp/jgX408H6ygl12E23kmQ3JJqh7MWfa/Ku1MA==",
+			"requires": {
+				"@airgap/beacon-blockchain-substrate": "4.0.4",
+				"@airgap/beacon-blockchain-tezos": "4.0.4",
+				"@airgap/beacon-core": "4.0.4",
+				"@airgap/beacon-dapp": "4.0.4",
+				"@airgap/beacon-transport-matrix": "4.0.4",
+				"@airgap/beacon-transport-postmessage": "4.0.4",
+				"@airgap/beacon-types": "4.0.4",
+				"@airgap/beacon-ui": "4.0.4",
+				"@airgap/beacon-utils": "4.0.4",
+				"@airgap/beacon-wallet": "4.0.4"
+			}
+		},
+		"@airgap/beacon-transport-matrix": {
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/@airgap/beacon-transport-matrix/-/beacon-transport-matrix-4.0.4.tgz",
+			"integrity": "sha512-vPei/HMimJgp4Ez0LFtNL399jLQaawDTVwsC5Fz7Y4Vsw4B6CP3rKlF6Y0RvY1TuFv5drK9cdA/dymRsvW7G7w==",
+			"requires": {
+				"@airgap/beacon-core": "4.0.4",
+				"@airgap/beacon-utils": "4.0.4",
+				"axios": "0.24.0"
+			}
+		},
+		"@airgap/beacon-transport-postmessage": {
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/@airgap/beacon-transport-postmessage/-/beacon-transport-postmessage-4.0.4.tgz",
+			"integrity": "sha512-AdNPKEzoXo1lp4sgsMeeLEyHmZw/KnUVxSIjwoZpK+wn7E97uxJ6H+ecsq9zxpGtnoQ2Yt1AnSJJq8iofuwguA==",
+			"requires": {
+				"@airgap/beacon-core": "4.0.4",
+				"@airgap/beacon-types": "4.0.4",
+				"@airgap/beacon-utils": "4.0.4"
+			}
+		},
+		"@airgap/beacon-transport-walletconnect": {
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/@airgap/beacon-transport-walletconnect/-/beacon-transport-walletconnect-4.0.4.tgz",
+			"integrity": "sha512-PBCErPUuE9oeixc7xeEYcwlJjnZ3WcCUs40SQ2tAE1N8uSkNX8D0kMb6r+WYHxWBjO91Uqq68x+3gPRXEIv6Kw==",
+			"requires": {
+				"@airgap/beacon-core": "4.0.4",
+				"@airgap/beacon-types": "4.0.4",
+				"@airgap/beacon-utils": "4.0.4",
+				"@walletconnect/sign-client": "^2.7.5"
+			}
+		},
+		"@airgap/beacon-types": {
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/@airgap/beacon-types/-/beacon-types-4.0.4.tgz",
+			"integrity": "sha512-QIjsSkk+sdw9pcL6DybsQrlkHVqRmGFEr0N/YDlSNsnfGPH/q3O/dE+gfuiV93+bYM6WLbN4nd+nPt1xb0BCsw==",
+			"requires": {
+				"@types/chrome": "0.0.163"
+			}
+		},
+		"@airgap/beacon-ui": {
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/@airgap/beacon-ui/-/beacon-ui-4.0.4.tgz",
+			"integrity": "sha512-QVVQGX272ebXS/JBRNwhbCqN7RDIG68nuQpil0dnrY8HMb9lVJV5GOuFIBf+3fyj6rpDbfyCKK3UgOSX1ZIrSA==",
+			"requires": {
+				"@airgap/beacon-core": "4.0.4",
+				"@airgap/beacon-transport-postmessage": "4.0.4",
+				"@airgap/beacon-types": "4.0.4",
+				"@airgap/beacon-utils": "4.0.4",
+				"qrcode-svg": "^1.1.0",
+				"solid-js": "^1.6.6"
+			}
+		},
+		"@airgap/beacon-utils": {
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/@airgap/beacon-utils/-/beacon-utils-4.0.4.tgz",
+			"integrity": "sha512-95srMpUjwfE8BfdrDlApt4saxQsUI3z5LLXnjycTYCQ261eznQBhRjTHbYNPfNpw1wsvv/QN2T99FG06UOluIA==",
+			"requires": {
+				"@stablelib/ed25519": "^1.0.3",
+				"@stablelib/nacl": "^1.0.3",
+				"@stablelib/random": "^1.0.2",
+				"@stablelib/utf8": "^1.0.1",
+				"bs58check": "2.1.2"
+			}
+		},
+		"@airgap/beacon-wallet": {
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/@airgap/beacon-wallet/-/beacon-wallet-4.0.4.tgz",
+			"integrity": "sha512-PWk0Mfhu9741soyGuJPPzbZuUx+UuRltoFJbyUMR8kd3gNb2yElrlldFoNJo7Tk/e/Ib/+nXYWQrbAfhjpRkCw==",
+			"requires": {
+				"@airgap/beacon-core": "4.0.4",
+				"@airgap/beacon-transport-matrix": "4.0.4",
+				"@airgap/beacon-transport-postmessage": "4.0.4"
+			}
+		},
 		"@ampproject/remapping": {
 			"version": "2.2.1",
 			"resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.2.1.tgz",
 			"integrity": "sha512-lFMjJTrFL3j7L9yBxwYfCq2k6qqwHyzuUl/XBnif78PWTJYyL/dfowQHWE3sp6U6ZzqWiiIZnpTMO96zhkjwtg==",
-			"dev": true,
 			"requires": {
 				"@jridgewell/gen-mapping": "^0.3.0",
 				"@jridgewell/trace-mapping": "^0.3.9"
 			}
 		},
+		"@esbuild-plugins/node-globals-polyfill": {
+			"version": "0.2.3",
+			"resolved": "https://registry.npmjs.org/@esbuild-plugins/node-globals-polyfill/-/node-globals-polyfill-0.2.3.tgz",
+			"integrity": "sha512-r3MIryXDeXDOZh7ih1l/yE9ZLORCd5e8vWg02azWRGj5SPTuoh69A2AIyn0Z31V/kHBfZ4HgWJ+OK3GTTwLmnw==",
+			"requires": {}
+		},
 		"@esbuild/android-arm": {
 			"version": "0.17.19",
 			"resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.17.19.tgz",
 			"integrity": "sha512-rIKddzqhmav7MSmoFCmDIb6e2W57geRsM94gV2l38fzhXMwq7hZoClug9USI2pFRGL06f4IOPHHpFNOkWieR8A==",
-			"dev": true,
 			"optional": true
 		},
 		"@esbuild/android-arm64": {
 			"version": "0.17.19",
 			"resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.17.19.tgz",
 			"integrity": "sha512-KBMWvEZooR7+kzY0BtbTQn0OAYY7CsiydT63pVEaPtVYF0hXbUaOyZog37DKxK7NF3XacBJOpYT4adIJh+avxA==",
-			"dev": true,
 			"optional": true
 		},
 		"@esbuild/android-x64": {
 			"version": "0.17.19",
 			"resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.17.19.tgz",
 			"integrity": "sha512-uUTTc4xGNDT7YSArp/zbtmbhO0uEEK9/ETW29Wk1thYUJBz3IVnvgEiEwEa9IeLyvnpKrWK64Utw2bgUmDveww==",
-			"dev": true,
 			"optional": true
 		},
 		"@esbuild/darwin-arm64": {
 			"version": "0.17.19",
 			"resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.17.19.tgz",
 			"integrity": "sha512-80wEoCfF/hFKM6WE1FyBHc9SfUblloAWx6FJkFWTWiCoht9Mc0ARGEM47e67W9rI09YoUxJL68WHfDRYEAvOhg==",
-			"dev": true,
 			"optional": true
 		},
 		"@esbuild/darwin-x64": {
 			"version": "0.17.19",
 			"resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.17.19.tgz",
 			"integrity": "sha512-IJM4JJsLhRYr9xdtLytPLSH9k/oxR3boaUIYiHkAawtwNOXKE8KoU8tMvryogdcT8AU+Bflmh81Xn6Q0vTZbQw==",
-			"dev": true,
 			"optional": true
 		},
 		"@esbuild/freebsd-arm64": {
 			"version": "0.17.19",
 			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.17.19.tgz",
 			"integrity": "sha512-pBwbc7DufluUeGdjSU5Si+P3SoMF5DQ/F/UmTSb8HXO80ZEAJmrykPyzo1IfNbAoaqw48YRpv8shwd1NoI0jcQ==",
-			"dev": true,
 			"optional": true
 		},
 		"@esbuild/freebsd-x64": {
 			"version": "0.17.19",
 			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.17.19.tgz",
 			"integrity": "sha512-4lu+n8Wk0XlajEhbEffdy2xy53dpR06SlzvhGByyg36qJw6Kpfk7cp45DR/62aPH9mtJRmIyrXAS5UWBrJT6TQ==",
-			"dev": true,
 			"optional": true
 		},
 		"@esbuild/linux-arm": {
 			"version": "0.17.19",
 			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.17.19.tgz",
 			"integrity": "sha512-cdmT3KxjlOQ/gZ2cjfrQOtmhG4HJs6hhvm3mWSRDPtZ/lP5oe8FWceS10JaSJC13GBd4eH/haHnqf7hhGNLerA==",
-			"dev": true,
 			"optional": true
 		},
 		"@esbuild/linux-arm64": {
 			"version": "0.17.19",
 			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.17.19.tgz",
 			"integrity": "sha512-ct1Tg3WGwd3P+oZYqic+YZF4snNl2bsnMKRkb3ozHmnM0dGWuxcPTTntAF6bOP0Sp4x0PjSF+4uHQ1xvxfRKqg==",
-			"dev": true,
 			"optional": true
 		},
 		"@esbuild/linux-ia32": {
 			"version": "0.17.19",
 			"resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.17.19.tgz",
 			"integrity": "sha512-w4IRhSy1VbsNxHRQpeGCHEmibqdTUx61Vc38APcsRbuVgK0OPEnQ0YD39Brymn96mOx48Y2laBQGqgZ0j9w6SQ==",
-			"dev": true,
 			"optional": true
 		},
 		"@esbuild/linux-loong64": {
 			"version": "0.17.19",
 			"resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.17.19.tgz",
 			"integrity": "sha512-2iAngUbBPMq439a+z//gE+9WBldoMp1s5GWsUSgqHLzLJ9WoZLZhpwWuym0u0u/4XmZ3gpHmzV84PonE+9IIdQ==",
-			"dev": true,
 			"optional": true
 		},
 		"@esbuild/linux-mips64el": {
 			"version": "0.17.19",
 			"resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.17.19.tgz",
 			"integrity": "sha512-LKJltc4LVdMKHsrFe4MGNPp0hqDFA1Wpt3jE1gEyM3nKUvOiO//9PheZZHfYRfYl6AwdTH4aTcXSqBerX0ml4A==",
-			"dev": true,
 			"optional": true
 		},
 		"@esbuild/linux-ppc64": {
 			"version": "0.17.19",
 			"resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.17.19.tgz",
 			"integrity": "sha512-/c/DGybs95WXNS8y3Ti/ytqETiW7EU44MEKuCAcpPto3YjQbyK3IQVKfF6nbghD7EcLUGl0NbiL5Rt5DMhn5tg==",
-			"dev": true,
 			"optional": true
 		},
 		"@esbuild/linux-riscv64": {
 			"version": "0.17.19",
 			"resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.17.19.tgz",
 			"integrity": "sha512-FC3nUAWhvFoutlhAkgHf8f5HwFWUL6bYdvLc/TTuxKlvLi3+pPzdZiFKSWz/PF30TB1K19SuCxDTI5KcqASJqA==",
-			"dev": true,
 			"optional": true
 		},
 		"@esbuild/linux-s390x": {
 			"version": "0.17.19",
 			"resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.17.19.tgz",
 			"integrity": "sha512-IbFsFbxMWLuKEbH+7sTkKzL6NJmG2vRyy6K7JJo55w+8xDk7RElYn6xvXtDW8HCfoKBFK69f3pgBJSUSQPr+4Q==",
-			"dev": true,
 			"optional": true
 		},
 		"@esbuild/linux-x64": {
 			"version": "0.17.19",
 			"resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.17.19.tgz",
 			"integrity": "sha512-68ngA9lg2H6zkZcyp22tsVt38mlhWde8l3eJLWkyLrp4HwMUr3c1s/M2t7+kHIhvMjglIBrFpncX1SzMckomGw==",
-			"dev": true,
 			"optional": true
 		},
 		"@esbuild/netbsd-x64": {
 			"version": "0.17.19",
 			"resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.17.19.tgz",
 			"integrity": "sha512-CwFq42rXCR8TYIjIfpXCbRX0rp1jo6cPIUPSaWwzbVI4aOfX96OXY8M6KNmtPcg7QjYeDmN+DD0Wp3LaBOLf4Q==",
-			"dev": true,
 			"optional": true
 		},
 		"@esbuild/openbsd-x64": {
 			"version": "0.17.19",
 			"resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.17.19.tgz",
 			"integrity": "sha512-cnq5brJYrSZ2CF6c35eCmviIN3k3RczmHz8eYaVlNasVqsNY+JKohZU5MKmaOI+KkllCdzOKKdPs762VCPC20g==",
-			"dev": true,
 			"optional": true
 		},
 		"@esbuild/sunos-x64": {
 			"version": "0.17.19",
 			"resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.17.19.tgz",
 			"integrity": "sha512-vCRT7yP3zX+bKWFeP/zdS6SqdWB8OIpaRq/mbXQxTGHnIxspRtigpkUcDMlSCOejlHowLqII7K2JKevwyRP2rg==",
-			"dev": true,
 			"optional": true
 		},
 		"@esbuild/win32-arm64": {
 			"version": "0.17.19",
 			"resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.17.19.tgz",
 			"integrity": "sha512-yYx+8jwowUstVdorcMdNlzklLYhPxjniHWFKgRqH7IFlUEa0Umu3KuYplf1HUZZ422e3NU9F4LGb+4O0Kdcaag==",
-			"dev": true,
 			"optional": true
 		},
 		"@esbuild/win32-ia32": {
 			"version": "0.17.19",
 			"resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.17.19.tgz",
 			"integrity": "sha512-eggDKanJszUtCdlVs0RB+h35wNlb5v4TWEkq4vZcmVt5u/HiDZrTXe2bWFQUez3RgNHwx/x4sk5++4NSSicKkw==",
-			"dev": true,
 			"optional": true
 		},
 		"@esbuild/win32-x64": {
 			"version": "0.17.19",
 			"resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.17.19.tgz",
 			"integrity": "sha512-lAhycmKnVOuRYNtRtatQR1LPQf2oYCkRGkSFnseDAKPl8lu5SOsK/e1sXe5a0Pc5kHIHe6P2I/ilntNv2xf3cA==",
-			"dev": true,
 			"optional": true
 		},
 		"@eslint-community/eslint-utils": {
@@ -3400,7 +5094,6 @@
 			"version": "0.3.3",
 			"resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.3.tgz",
 			"integrity": "sha512-HLhSWOLRi875zjjMG/r+Nv0oCW8umGb0BgEhyX3dDX3egwZtB8PqLnjz3yedt8R5StBrzcg4aBpnh8UA9D1BoQ==",
-			"dev": true,
 			"requires": {
 				"@jridgewell/set-array": "^1.0.1",
 				"@jridgewell/sourcemap-codec": "^1.4.10",
@@ -3410,26 +5103,22 @@
 		"@jridgewell/resolve-uri": {
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.0.tgz",
-			"integrity": "sha512-F2msla3tad+Mfht5cJq7LSXcdudKTWCVYUgw6pLFOOHSTtZlj6SWNYAp+AhuqLmWdBO2X5hPrLcu8cVP8fy28w==",
-			"dev": true
+			"integrity": "sha512-F2msla3tad+Mfht5cJq7LSXcdudKTWCVYUgw6pLFOOHSTtZlj6SWNYAp+AhuqLmWdBO2X5hPrLcu8cVP8fy28w=="
 		},
 		"@jridgewell/set-array": {
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.1.2.tgz",
-			"integrity": "sha512-xnkseuNADM0gt2bs+BvhO0p78Mk762YnZdsuzFV018NoG1Sj1SCQvpSqa7XUaTam5vAGasABV9qXASMKnFMwMw==",
-			"dev": true
+			"integrity": "sha512-xnkseuNADM0gt2bs+BvhO0p78Mk762YnZdsuzFV018NoG1Sj1SCQvpSqa7XUaTam5vAGasABV9qXASMKnFMwMw=="
 		},
 		"@jridgewell/sourcemap-codec": {
 			"version": "1.4.15",
 			"resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.15.tgz",
-			"integrity": "sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg==",
-			"dev": true
+			"integrity": "sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg=="
 		},
 		"@jridgewell/trace-mapping": {
 			"version": "0.3.18",
 			"resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.18.tgz",
 			"integrity": "sha512-w+niJYzMHdd7USdiH2U6869nqhD2nbfZXND5Yp93qIbEmnDNk7PD48o+YchRVpzMU7M6jVCbenTR7PA1FLQ9pA==",
-			"dev": true,
 			"requires": {
 				"@jridgewell/resolve-uri": "3.1.0",
 				"@jridgewell/sourcemap-codec": "1.4.14"
@@ -3438,8 +5127,7 @@
 				"@jridgewell/sourcemap-codec": {
 					"version": "1.4.14",
 					"resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.14.tgz",
-					"integrity": "sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw==",
-					"dev": true
+					"integrity": "sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw=="
 				}
 			}
 		},
@@ -3474,6 +5162,211 @@
 			"resolved": "https://registry.npmjs.org/@polka/url/-/url-1.0.0-next.21.tgz",
 			"integrity": "sha512-a5Sab1C4/icpTZVzZc5Ghpz88yQtGOyNqYXcZgOssB2uuAr+wF/MvN6bgtW32q7HHrvBki+BsZ0OuNv6EV3K9g==",
 			"dev": true
+		},
+		"@stablelib/aead": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@stablelib/aead/-/aead-1.0.1.tgz",
+			"integrity": "sha512-q39ik6sxGHewqtO0nP4BuSe3db5G1fEJE8ukvngS2gLkBXyy6E7pLubhbYgnkDFv6V8cWaxcE4Xn0t6LWcJkyg=="
+		},
+		"@stablelib/binary": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@stablelib/binary/-/binary-1.0.1.tgz",
+			"integrity": "sha512-ClJWvmL6UBM/wjkvv/7m5VP3GMr9t0osr4yVgLZsLCOz4hGN9gIAFEqnJ0TsSMAN+n840nf2cHZnA5/KFqHC7Q==",
+			"requires": {
+				"@stablelib/int": "^1.0.1"
+			}
+		},
+		"@stablelib/blake2b": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@stablelib/blake2b/-/blake2b-1.0.1.tgz",
+			"integrity": "sha512-B3KyKoBAjkIFeH7romcF96i+pVFYk7K2SBQ1pZvaxV+epSBXJ+n0C66esUhyz6FF+5FbdQVm77C5fzGFcEZpKA==",
+			"requires": {
+				"@stablelib/binary": "^1.0.1",
+				"@stablelib/hash": "^1.0.1",
+				"@stablelib/wipe": "^1.0.1"
+			}
+		},
+		"@stablelib/bytes": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@stablelib/bytes/-/bytes-1.0.1.tgz",
+			"integrity": "sha512-Kre4Y4kdwuqL8BR2E9hV/R5sOrUj6NanZaZis0V6lX5yzqC3hBuVSDXUIBqQv/sCpmuWRiHLwqiT1pqqjuBXoQ=="
+		},
+		"@stablelib/chacha": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@stablelib/chacha/-/chacha-1.0.1.tgz",
+			"integrity": "sha512-Pmlrswzr0pBzDofdFuVe1q7KdsHKhhU24e8gkEwnTGOmlC7PADzLVxGdn2PoNVBBabdg0l/IfLKg6sHAbTQugg==",
+			"requires": {
+				"@stablelib/binary": "^1.0.1",
+				"@stablelib/wipe": "^1.0.1"
+			}
+		},
+		"@stablelib/chacha20poly1305": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@stablelib/chacha20poly1305/-/chacha20poly1305-1.0.1.tgz",
+			"integrity": "sha512-MmViqnqHd1ymwjOQfghRKw2R/jMIGT3wySN7cthjXCBdO+qErNPUBnRzqNpnvIwg7JBCg3LdeCZZO4de/yEhVA==",
+			"requires": {
+				"@stablelib/aead": "^1.0.1",
+				"@stablelib/binary": "^1.0.1",
+				"@stablelib/chacha": "^1.0.1",
+				"@stablelib/constant-time": "^1.0.1",
+				"@stablelib/poly1305": "^1.0.1",
+				"@stablelib/wipe": "^1.0.1"
+			}
+		},
+		"@stablelib/constant-time": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@stablelib/constant-time/-/constant-time-1.0.1.tgz",
+			"integrity": "sha512-tNOs3uD0vSJcK6z1fvef4Y+buN7DXhzHDPqRLSXUel1UfqMB1PWNsnnAezrKfEwTLpN0cGH2p9NNjs6IqeD0eg=="
+		},
+		"@stablelib/ed25519": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/@stablelib/ed25519/-/ed25519-1.0.3.tgz",
+			"integrity": "sha512-puIMWaX9QlRsbhxfDc5i+mNPMY+0TmQEskunY1rZEBPi1acBCVQAhnsk/1Hk50DGPtVsZtAWQg4NHGlVaO9Hqg==",
+			"requires": {
+				"@stablelib/random": "^1.0.2",
+				"@stablelib/sha512": "^1.0.1",
+				"@stablelib/wipe": "^1.0.1"
+			}
+		},
+		"@stablelib/hash": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@stablelib/hash/-/hash-1.0.1.tgz",
+			"integrity": "sha512-eTPJc/stDkdtOcrNMZ6mcMK1e6yBbqRBaNW55XA1jU8w/7QdnCF0CmMmOD1m7VSkBR44PWrMHU2l6r8YEQHMgg=="
+		},
+		"@stablelib/hkdf": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@stablelib/hkdf/-/hkdf-1.0.1.tgz",
+			"integrity": "sha512-SBEHYE16ZXlHuaW5RcGk533YlBj4grMeg5TooN80W3NpcHRtLZLLXvKyX0qcRFxf+BGDobJLnwkvgEwHIDBR6g==",
+			"requires": {
+				"@stablelib/hash": "^1.0.1",
+				"@stablelib/hmac": "^1.0.1",
+				"@stablelib/wipe": "^1.0.1"
+			}
+		},
+		"@stablelib/hmac": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@stablelib/hmac/-/hmac-1.0.1.tgz",
+			"integrity": "sha512-V2APD9NSnhVpV/QMYgCVMIYKiYG6LSqw1S65wxVoirhU/51ACio6D4yDVSwMzuTJXWZoVHbDdINioBwKy5kVmA==",
+			"requires": {
+				"@stablelib/constant-time": "^1.0.1",
+				"@stablelib/hash": "^1.0.1",
+				"@stablelib/wipe": "^1.0.1"
+			}
+		},
+		"@stablelib/int": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@stablelib/int/-/int-1.0.1.tgz",
+			"integrity": "sha512-byr69X/sDtDiIjIV6m4roLVWnNNlRGzsvxw+agj8CIEazqWGOQp2dTYgQhtyVXV9wpO6WyXRQUzLV/JRNumT2w=="
+		},
+		"@stablelib/keyagreement": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@stablelib/keyagreement/-/keyagreement-1.0.1.tgz",
+			"integrity": "sha512-VKL6xBwgJnI6l1jKrBAfn265cspaWBPAPEc62VBQrWHLqVgNRE09gQ/AnOEyKUWrrqfD+xSQ3u42gJjLDdMDQg==",
+			"requires": {
+				"@stablelib/bytes": "^1.0.1"
+			}
+		},
+		"@stablelib/nacl": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/@stablelib/nacl/-/nacl-1.0.4.tgz",
+			"integrity": "sha512-PJ2U/MrkXSKUM8C4qFs87WeCNxri7KQwR8Cdwm9q2sweGuAtTvOJGuW0F3N+zn+ySLPJA98SYWSSpogMJ1gCmw==",
+			"requires": {
+				"@stablelib/poly1305": "^1.0.1",
+				"@stablelib/random": "^1.0.2",
+				"@stablelib/wipe": "^1.0.1",
+				"@stablelib/x25519": "^1.0.3",
+				"@stablelib/xsalsa20": "^1.0.2"
+			}
+		},
+		"@stablelib/poly1305": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@stablelib/poly1305/-/poly1305-1.0.1.tgz",
+			"integrity": "sha512-1HlG3oTSuQDOhSnLwJRKeTRSAdFNVB/1djy2ZbS35rBSJ/PFqx9cf9qatinWghC2UbfOYD8AcrtbUQl8WoxabA==",
+			"requires": {
+				"@stablelib/constant-time": "^1.0.1",
+				"@stablelib/wipe": "^1.0.1"
+			}
+		},
+		"@stablelib/random": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/@stablelib/random/-/random-1.0.2.tgz",
+			"integrity": "sha512-rIsE83Xpb7clHPVRlBj8qNe5L8ISQOzjghYQm/dZ7VaM2KHYwMW5adjQjrzTZCchFnNCNhkwtnOBa9HTMJCI8w==",
+			"requires": {
+				"@stablelib/binary": "^1.0.1",
+				"@stablelib/wipe": "^1.0.1"
+			}
+		},
+		"@stablelib/salsa20": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/@stablelib/salsa20/-/salsa20-1.0.2.tgz",
+			"integrity": "sha512-nfjKzw0KTKrrKBasEP+j7UP4I8Xudom8lVZIBCp0kQNARXq72IlSic0oabg2FC1NU68L4RdHrNJDd8bFwrphYA==",
+			"requires": {
+				"@stablelib/binary": "^1.0.1",
+				"@stablelib/constant-time": "^1.0.1",
+				"@stablelib/wipe": "^1.0.1"
+			}
+		},
+		"@stablelib/sha256": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@stablelib/sha256/-/sha256-1.0.1.tgz",
+			"integrity": "sha512-GIIH3e6KH+91FqGV42Kcj71Uefd/QEe7Dy42sBTeqppXV95ggCcxLTk39bEr+lZfJmp+ghsR07J++ORkRELsBQ==",
+			"requires": {
+				"@stablelib/binary": "^1.0.1",
+				"@stablelib/hash": "^1.0.1",
+				"@stablelib/wipe": "^1.0.1"
+			}
+		},
+		"@stablelib/sha512": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@stablelib/sha512/-/sha512-1.0.1.tgz",
+			"integrity": "sha512-13gl/iawHV9zvDKciLo1fQ8Bgn2Pvf7OV6amaRVKiq3pjQ3UmEpXxWiAfV8tYjUpeZroBxtyrwtdooQT/i3hzw==",
+			"requires": {
+				"@stablelib/binary": "^1.0.1",
+				"@stablelib/hash": "^1.0.1",
+				"@stablelib/wipe": "^1.0.1"
+			}
+		},
+		"@stablelib/utf8": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@stablelib/utf8/-/utf8-1.0.1.tgz",
+			"integrity": "sha512-FrYD1xadah/TtAP6VJ04lDD5h9rdDj/d8wH/jMYTtHqZBv9z2btdvEU8vTxdjdkFmo1b/BH+t3R1wi/mYhCCNg=="
+		},
+		"@stablelib/wipe": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@stablelib/wipe/-/wipe-1.0.1.tgz",
+			"integrity": "sha512-WfqfX/eXGiAd3RJe4VU2snh/ZPwtSjLG4ynQ/vYzvghTh7dHFcI1wl+nrkWG6lGhukOxOsUHfv8dUXr58D0ayg=="
+		},
+		"@stablelib/x25519": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/@stablelib/x25519/-/x25519-1.0.3.tgz",
+			"integrity": "sha512-KnTbKmUhPhHavzobclVJQG5kuivH+qDLpe84iRqX3CLrKp881cF160JvXJ+hjn1aMyCwYOKeIZefIH/P5cJoRw==",
+			"requires": {
+				"@stablelib/keyagreement": "^1.0.1",
+				"@stablelib/random": "^1.0.2",
+				"@stablelib/wipe": "^1.0.1"
+			}
+		},
+		"@stablelib/x25519-session": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/@stablelib/x25519-session/-/x25519-session-1.0.4.tgz",
+			"integrity": "sha512-UZw67EJWSNTaou7Qp086fzGek7crrCQl2K7MoqEzslXxrm6vybySfcdsqaZ0ZpKq19IHWK8G0wAlFBy70srm3w==",
+			"requires": {
+				"@stablelib/blake2b": "^1.0.1",
+				"@stablelib/keyagreement": "^1.0.1",
+				"@stablelib/random": "^1.0.2",
+				"@stablelib/wipe": "^1.0.1",
+				"@stablelib/x25519": "^1.0.3"
+			}
+		},
+		"@stablelib/xsalsa20": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/@stablelib/xsalsa20/-/xsalsa20-1.0.2.tgz",
+			"integrity": "sha512-7XdBGbcNgBShmuhDXv1G1WPVCkjZdkb1oPMzSidO7Fve0MHntH6TjFkj5bfLI+aRE+61weO076vYpP/jmaAYog==",
+			"requires": {
+				"@stablelib/binary": "^1.0.1",
+				"@stablelib/salsa20": "^1.0.2",
+				"@stablelib/wipe": "^1.0.1"
+			}
 		},
 		"@sveltejs/adapter-auto": {
 			"version": "2.1.0",
@@ -3528,6 +5421,306 @@
 				"debug": "^4.3.4"
 			}
 		},
+		"@taquito/beacon-wallet": {
+			"version": "17.0.0",
+			"resolved": "https://registry.npmjs.org/@taquito/beacon-wallet/-/beacon-wallet-17.0.0.tgz",
+			"integrity": "sha512-OKuN2V2xLMeSb0u3nfzSjZDYV4mIB4pur2eR8xa+NhkXlY0gkQXjmZ3K9lwtjKcU3GI0iv5IVod4blYyHNeNvg==",
+			"requires": {
+				"@airgap/beacon-dapp": "4.0.2",
+				"@taquito/core": "^17.0.0",
+				"@taquito/taquito": "^17.0.0"
+			},
+			"dependencies": {
+				"@airgap/beacon-core": {
+					"version": "4.0.2",
+					"resolved": "https://registry.npmjs.org/@airgap/beacon-core/-/beacon-core-4.0.2.tgz",
+					"integrity": "sha512-a6mAn6BfbejBQI95tRc6pIZ0VS6MTK9MZ7iXPTLF9hrnCHiROmrCgNKst8qp2dcE0Ehk7z/hGs2WliJzi657YA==",
+					"requires": {
+						"@airgap/beacon-types": "4.0.2",
+						"@airgap/beacon-utils": "4.0.2",
+						"@stablelib/ed25519": "^1.0.3",
+						"@stablelib/nacl": "^1.0.4",
+						"@stablelib/utf8": "^1.0.1",
+						"@stablelib/x25519-session": "^1.0.4",
+						"bs58check": "2.1.2"
+					}
+				},
+				"@airgap/beacon-dapp": {
+					"version": "4.0.2",
+					"resolved": "https://registry.npmjs.org/@airgap/beacon-dapp/-/beacon-dapp-4.0.2.tgz",
+					"integrity": "sha512-7vjvcM470GPfDkizYpuUzJ7Fus7X/zkFeXYTkxx69Dt5TlmKg09YNfRtvrFMDbf4OKnjbaRfVhqzwfYkpaRbPg==",
+					"requires": {
+						"@airgap/beacon-core": "4.0.2",
+						"@airgap/beacon-transport-matrix": "4.0.2",
+						"@airgap/beacon-transport-postmessage": "4.0.2",
+						"@airgap/beacon-transport-walletconnect": "4.0.2",
+						"@airgap/beacon-ui": "4.0.2"
+					}
+				},
+				"@airgap/beacon-transport-matrix": {
+					"version": "4.0.2",
+					"resolved": "https://registry.npmjs.org/@airgap/beacon-transport-matrix/-/beacon-transport-matrix-4.0.2.tgz",
+					"integrity": "sha512-sidXWA9QkcdpTLObsgMIIePq2+6eHn8djSK2UeoAWZpVOky+jpaIU78UlzqgDzMrO9inzu/xwsuXlk5Nmy1RyA==",
+					"requires": {
+						"@airgap/beacon-core": "4.0.2",
+						"@airgap/beacon-utils": "4.0.2",
+						"axios": "0.24.0"
+					}
+				},
+				"@airgap/beacon-transport-postmessage": {
+					"version": "4.0.2",
+					"resolved": "https://registry.npmjs.org/@airgap/beacon-transport-postmessage/-/beacon-transport-postmessage-4.0.2.tgz",
+					"integrity": "sha512-UDHigcIRD5/VdKX3YDj+CVHYWafYg3N8nHT5yQ2JOU5nsQhD2y5NNNp/7U7I44CcD4OeK9d2slV+lnp8lBYe1g==",
+					"requires": {
+						"@airgap/beacon-core": "4.0.2",
+						"@airgap/beacon-types": "4.0.2",
+						"@airgap/beacon-utils": "4.0.2"
+					}
+				},
+				"@airgap/beacon-transport-walletconnect": {
+					"version": "4.0.2",
+					"resolved": "https://registry.npmjs.org/@airgap/beacon-transport-walletconnect/-/beacon-transport-walletconnect-4.0.2.tgz",
+					"integrity": "sha512-t4ZrgyImVf8UIhVa6ei/p1STVKNdRq5WSoop8eTSqArIHVj4zk2dr5J0ihbe64UyLAX1O0Z7yV+dUVoH+kVWGw==",
+					"requires": {
+						"@airgap/beacon-core": "4.0.2",
+						"@airgap/beacon-types": "4.0.2",
+						"@airgap/beacon-utils": "4.0.2",
+						"@walletconnect/sign-client": "2.7.0"
+					}
+				},
+				"@airgap/beacon-types": {
+					"version": "4.0.2",
+					"resolved": "https://registry.npmjs.org/@airgap/beacon-types/-/beacon-types-4.0.2.tgz",
+					"integrity": "sha512-MWbE+350Yd7aICBEwTVIkty/YmKO5eTDsMbReUCNH8qf64gGhj/ZXEN6FPwMab+qKdmACgCkmbbtAXGGtmjwrA==",
+					"requires": {
+						"@types/chrome": "0.0.163"
+					}
+				},
+				"@airgap/beacon-ui": {
+					"version": "4.0.2",
+					"resolved": "https://registry.npmjs.org/@airgap/beacon-ui/-/beacon-ui-4.0.2.tgz",
+					"integrity": "sha512-ZTcvdQ5GNlQ58M0Fduoq/KqsulBXeBN6jKiHnzHM3e98syy953DKQoDhU2NXNZiJ7AvEGO3s/fd+BN8y/+CVuQ==",
+					"requires": {
+						"@airgap/beacon-core": "4.0.2",
+						"@airgap/beacon-transport-postmessage": "4.0.2",
+						"@airgap/beacon-types": "4.0.2",
+						"@airgap/beacon-utils": "4.0.2",
+						"qrcode-svg": "^1.1.0",
+						"solid-js": "^1.6.6"
+					}
+				},
+				"@airgap/beacon-utils": {
+					"version": "4.0.2",
+					"resolved": "https://registry.npmjs.org/@airgap/beacon-utils/-/beacon-utils-4.0.2.tgz",
+					"integrity": "sha512-5TfOI3ZolQQ9WNHogEO3SY4M2Paqbb3hf8DvolFofST6Brp0qyxkwZ0i99puahgwRo+B0qGilZpkLCYl72DMQg==",
+					"requires": {
+						"@stablelib/ed25519": "^1.0.3",
+						"@stablelib/nacl": "^1.0.3",
+						"@stablelib/random": "^1.0.2",
+						"@stablelib/utf8": "^1.0.1",
+						"bs58check": "2.1.2"
+					}
+				},
+				"@walletconnect/core": {
+					"version": "2.7.0",
+					"resolved": "https://registry.npmjs.org/@walletconnect/core/-/core-2.7.0.tgz",
+					"integrity": "sha512-xUeFPpElybgn1a+lknqtHleei4VyuV/4qWgB1nP8qQUAO6a5pNsioODrnB2VAPdUHJYBdx2dCt2maRk6g53IPQ==",
+					"requires": {
+						"@walletconnect/heartbeat": "1.2.1",
+						"@walletconnect/jsonrpc-provider": "^1.0.12",
+						"@walletconnect/jsonrpc-utils": "^1.0.7",
+						"@walletconnect/jsonrpc-ws-connection": "^1.0.11",
+						"@walletconnect/keyvaluestorage": "^1.0.2",
+						"@walletconnect/logger": "^2.0.1",
+						"@walletconnect/relay-api": "^1.0.9",
+						"@walletconnect/relay-auth": "^1.0.4",
+						"@walletconnect/safe-json": "^1.0.2",
+						"@walletconnect/time": "^1.0.2",
+						"@walletconnect/types": "2.7.0",
+						"@walletconnect/utils": "2.7.0",
+						"events": "^3.3.0",
+						"lodash.isequal": "4.5.0",
+						"uint8arrays": "^3.1.0"
+					}
+				},
+				"@walletconnect/sign-client": {
+					"version": "2.7.0",
+					"resolved": "https://registry.npmjs.org/@walletconnect/sign-client/-/sign-client-2.7.0.tgz",
+					"integrity": "sha512-K99xa6GSFS04U+140yrIEi/VJJJ0Q1ov4jCaiqa9euILDKxlBsM7m5GR+9sq6oYyj18SluJY4CJTdeOXUJlarA==",
+					"requires": {
+						"@walletconnect/core": "2.7.0",
+						"@walletconnect/events": "^1.0.1",
+						"@walletconnect/heartbeat": "1.2.1",
+						"@walletconnect/jsonrpc-utils": "^1.0.7",
+						"@walletconnect/logger": "^2.0.1",
+						"@walletconnect/time": "^1.0.2",
+						"@walletconnect/types": "2.7.0",
+						"@walletconnect/utils": "2.7.0",
+						"events": "^3.3.0"
+					}
+				},
+				"@walletconnect/types": {
+					"version": "2.7.0",
+					"resolved": "https://registry.npmjs.org/@walletconnect/types/-/types-2.7.0.tgz",
+					"integrity": "sha512-aMUDUtO79WSBtC/bDetE6aFwdgwJr0tJ8nC8gnAl5ELsrjygEKCn6M8Q+v6nP9svG9yf5Rds4cImxCT6BWwTyw==",
+					"requires": {
+						"@walletconnect/events": "^1.0.1",
+						"@walletconnect/heartbeat": "1.2.1",
+						"@walletconnect/jsonrpc-types": "^1.0.2",
+						"@walletconnect/keyvaluestorage": "^1.0.2",
+						"@walletconnect/logger": "^2.0.1",
+						"events": "^3.3.0"
+					}
+				},
+				"@walletconnect/utils": {
+					"version": "2.7.0",
+					"resolved": "https://registry.npmjs.org/@walletconnect/utils/-/utils-2.7.0.tgz",
+					"integrity": "sha512-k32jrQeyJsNZPdmtmg85Y3QgaS5YfzYSPrAxRC2uUD1ts7rrI6P5GG2iXNs3AvWKOuCgsp/PqU8s7AC7CRUscw==",
+					"requires": {
+						"@stablelib/chacha20poly1305": "1.0.1",
+						"@stablelib/hkdf": "1.0.1",
+						"@stablelib/random": "^1.0.2",
+						"@stablelib/sha256": "1.0.1",
+						"@stablelib/x25519": "^1.0.3",
+						"@walletconnect/jsonrpc-utils": "^1.0.7",
+						"@walletconnect/relay-api": "^1.0.9",
+						"@walletconnect/safe-json": "^1.0.2",
+						"@walletconnect/time": "^1.0.2",
+						"@walletconnect/types": "2.7.0",
+						"@walletconnect/window-getters": "^1.0.1",
+						"@walletconnect/window-metadata": "^1.0.1",
+						"detect-browser": "5.3.0",
+						"query-string": "7.1.1",
+						"uint8arrays": "^3.1.0"
+					}
+				},
+				"query-string": {
+					"version": "7.1.1",
+					"resolved": "https://registry.npmjs.org/query-string/-/query-string-7.1.1.tgz",
+					"integrity": "sha512-MplouLRDHBZSG9z7fpuAAcI7aAYjDLhtsiVZsevsfaHWDS2IDdORKbSd1kWUA+V4zyva/HZoSfpwnYMMQDhb0w==",
+					"requires": {
+						"decode-uri-component": "^0.2.0",
+						"filter-obj": "^1.1.0",
+						"split-on-first": "^1.0.0",
+						"strict-uri-encode": "^2.0.0"
+					}
+				}
+			}
+		},
+		"@taquito/core": {
+			"version": "17.0.0",
+			"resolved": "https://registry.npmjs.org/@taquito/core/-/core-17.0.0.tgz",
+			"integrity": "sha512-N+ww8+whR8T07XZLlcEyjTQCYfAZif9s1dTqagWW0V9l/EIXsnl1tL2MBfZnVcJDMhKoIk1MjofS0gYc0hld2Q=="
+		},
+		"@taquito/http-utils": {
+			"version": "17.0.0",
+			"resolved": "https://registry.npmjs.org/@taquito/http-utils/-/http-utils-17.0.0.tgz",
+			"integrity": "sha512-oyzZEr7k/HUQotFGGegXyixmUOB9jWsypTjWDmuElutDmO0GjFh33zii7vn57kZ1GmX4f0z45yiBp0w3flvhbA==",
+			"requires": {
+				"@taquito/core": "^17.0.0",
+				"axios": "^0.26.0"
+			},
+			"dependencies": {
+				"axios": {
+					"version": "0.26.1",
+					"resolved": "https://registry.npmjs.org/axios/-/axios-0.26.1.tgz",
+					"integrity": "sha512-fPwcX4EvnSHuInCMItEhAGnaSEXRBjtzh9fOtsE6E1G6p7vl7edEeZe11QHf18+6+9gR5PbKV/sGKNaD8YaMeA==",
+					"requires": {
+						"follow-redirects": "^1.14.8"
+					}
+				}
+			}
+		},
+		"@taquito/local-forging": {
+			"version": "17.0.0",
+			"resolved": "https://registry.npmjs.org/@taquito/local-forging/-/local-forging-17.0.0.tgz",
+			"integrity": "sha512-5VSbNGFb9WX9o/7mg49PjnwNeYMbf4JRZvrmxxWcffvfaNFnNW5X1iys+I7kHQA6HivhX73d6lVBiJkq2cQ3ag==",
+			"requires": {
+				"@taquito/core": "^17.0.0",
+				"@taquito/utils": "^17.0.0",
+				"bignumber.js": "^9.1.0"
+			}
+		},
+		"@taquito/michel-codec": {
+			"version": "17.0.0",
+			"resolved": "https://registry.npmjs.org/@taquito/michel-codec/-/michel-codec-17.0.0.tgz",
+			"integrity": "sha512-0wD4r1bfBzoZ3QpxN7grD/gHt8RcNehQ7Ped4quKh4iGmNmd4ej+/LEvw/kX5082M4mGbUMC0UwH2Go+J6C1ow==",
+			"requires": {
+				"@taquito/core": "^17.0.0"
+			}
+		},
+		"@taquito/michelson-encoder": {
+			"version": "17.0.0",
+			"resolved": "https://registry.npmjs.org/@taquito/michelson-encoder/-/michelson-encoder-17.0.0.tgz",
+			"integrity": "sha512-K2y8i7qjniWwjgI2illmBSiWO5B7zYBwTPS+CMw9OsxfMSaw5z8x4dMeBw5Bumc1p2SWo/jcU9U5qOnTVpxdeg==",
+			"requires": {
+				"@taquito/rpc": "^17.0.0",
+				"@taquito/utils": "^17.0.0",
+				"bignumber.js": "^9.1.0",
+				"fast-json-stable-stringify": "^2.1.0"
+			}
+		},
+		"@taquito/rpc": {
+			"version": "17.0.0",
+			"resolved": "https://registry.npmjs.org/@taquito/rpc/-/rpc-17.0.0.tgz",
+			"integrity": "sha512-5btSJNvdfHdoftXqUWheVh5pxos6YlmRb7q1A2z9Y49ocjz7wqr4aCuXeRsG1iESZ69V2DUr33t51joidVsDXA==",
+			"requires": {
+				"@taquito/core": "^17.0.0",
+				"@taquito/http-utils": "^17.0.0",
+				"@taquito/utils": "^17.0.0",
+				"bignumber.js": "^9.1.0"
+			}
+		},
+		"@taquito/taquito": {
+			"version": "17.0.0",
+			"resolved": "https://registry.npmjs.org/@taquito/taquito/-/taquito-17.0.0.tgz",
+			"integrity": "sha512-yLrP6lbgO4k1a9PoTDZxIasYmc3QxEJ4R59vgPPIlWQJfz0ZTBV9fPQNlwyTtRjjzgvX1gRN1VtpuddkcGjKrA==",
+			"requires": {
+				"@taquito/core": "^17.0.0",
+				"@taquito/http-utils": "^17.0.0",
+				"@taquito/local-forging": "^17.0.0",
+				"@taquito/michel-codec": "^17.0.0",
+				"@taquito/michelson-encoder": "^17.0.0",
+				"@taquito/rpc": "^17.0.0",
+				"@taquito/utils": "^17.0.0",
+				"bignumber.js": "^9.1.0",
+				"rxjs": "^6.6.3"
+			}
+		},
+		"@taquito/utils": {
+			"version": "17.0.0",
+			"resolved": "https://registry.npmjs.org/@taquito/utils/-/utils-17.0.0.tgz",
+			"integrity": "sha512-/Bg4UoQenriINVK727OpK0AWe1x1SFSdiRZD3cGMMu2fXaFQdG2Hx031bf46GN+Tqk/PuDchjA83UfQk05qBXQ==",
+			"requires": {
+				"@stablelib/blake2b": "^1.0.1",
+				"@stablelib/ed25519": "^1.0.3",
+				"@taquito/core": "^17.0.0",
+				"@types/bs58check": "^2.1.0",
+				"bignumber.js": "^9.1.0",
+				"blakejs": "^1.2.1",
+				"bs58check": "^2.1.2",
+				"buffer": "^6.0.3",
+				"elliptic": "^6.5.4",
+				"typedarray-to-buffer": "^4.0.0"
+			}
+		},
+		"@types/bs58check": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/@types/bs58check/-/bs58check-2.1.0.tgz",
+			"integrity": "sha512-OxsysnJQh82vy9DRbOcw9m2j/WiyqZLn0YBhKxdQ+aCwoHj+tWzyCgpwAkr79IfDXZKxc6h7k89T9pwS78CqTQ==",
+			"requires": {
+				"@types/node": "*"
+			}
+		},
+		"@types/chrome": {
+			"version": "0.0.163",
+			"resolved": "https://registry.npmjs.org/@types/chrome/-/chrome-0.0.163.tgz",
+			"integrity": "sha512-g+3E2tg/ukFsEgH+tB3a/b+J1VSvq/8gh2Jwih9eq+T3Idrz7ngj97u+/ya58Bfei2TQtPlRivj1FsCaSnukDA==",
+			"requires": {
+				"@types/filesystem": "*",
+				"@types/har-format": "*"
+			}
+		},
 		"@types/cookie": {
 			"version": "0.5.1",
 			"resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.5.1.tgz",
@@ -3537,14 +5730,36 @@
 		"@types/estree": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.1.tgz",
-			"integrity": "sha512-LG4opVs2ANWZ1TJoKc937iMmNstM/d0ae1vNbnBvBhqCSezgVUOzcLCqbI5elV8Vy6WKwKjaqR+zO9VKirBBCA==",
-			"dev": true
+			"integrity": "sha512-LG4opVs2ANWZ1TJoKc937iMmNstM/d0ae1vNbnBvBhqCSezgVUOzcLCqbI5elV8Vy6WKwKjaqR+zO9VKirBBCA=="
+		},
+		"@types/filesystem": {
+			"version": "0.0.32",
+			"resolved": "https://registry.npmjs.org/@types/filesystem/-/filesystem-0.0.32.tgz",
+			"integrity": "sha512-Yuf4jR5YYMR2DVgwuCiP11s0xuVRyPKmz8vo6HBY3CGdeMj8af93CFZX+T82+VD1+UqHOxTq31lO7MI7lepBtQ==",
+			"requires": {
+				"@types/filewriter": "*"
+			}
+		},
+		"@types/filewriter": {
+			"version": "0.0.29",
+			"resolved": "https://registry.npmjs.org/@types/filewriter/-/filewriter-0.0.29.tgz",
+			"integrity": "sha512-BsPXH/irW0ht0Ji6iw/jJaK8Lj3FJemon2gvEqHKpCdDCeemHa+rI3WBGq5z7cDMZgoLjY40oninGxqk+8NzNQ=="
+		},
+		"@types/har-format": {
+			"version": "1.2.11",
+			"resolved": "https://registry.npmjs.org/@types/har-format/-/har-format-1.2.11.tgz",
+			"integrity": "sha512-T232/TneofqK30AD1LRrrf8KnjLvzrjWDp7eWST5KoiSzrBfRsLrWDPk4STQPW4NZG6v2MltnduBVmakbZOBIQ=="
 		},
 		"@types/json-schema": {
 			"version": "7.0.12",
 			"resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.12.tgz",
 			"integrity": "sha512-Hr5Jfhc9eYOQNPYO5WLDq/n4jqijdHNlDXjuAQkkt+mWdQR+XJToOHrsD4cPaMXpn6KO7y2+wM8AZEs8VpBLVA==",
 			"dev": true
+		},
+		"@types/node": {
+			"version": "20.3.3",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-20.3.3.tgz",
+			"integrity": "sha512-wheIYdr4NYML61AjC8MKj/2jrR/kDQri/CIpVoZwldwhnIrD/j9jIU5bJ8yBKuB2VhpFV7Ab6G2XkBjv9r9Zzw=="
 		},
 		"@types/pug": {
 			"version": "2.0.6",
@@ -3657,11 +5872,329 @@
 				"eslint-visitor-keys": "^3.3.0"
 			}
 		},
+		"@walletconnect/core": {
+			"version": "2.8.6",
+			"resolved": "https://registry.npmjs.org/@walletconnect/core/-/core-2.8.6.tgz",
+			"integrity": "sha512-rnSqm1KJLcww/v6+UH8JeibQkJ3EKgyUDPfEK0stSEkrIUIcXaFlq3Et8S+vgV8bPhI0MVUhAhFL5OJZ3t2ryg==",
+			"requires": {
+				"@walletconnect/heartbeat": "1.2.1",
+				"@walletconnect/jsonrpc-provider": "1.0.13",
+				"@walletconnect/jsonrpc-types": "1.0.3",
+				"@walletconnect/jsonrpc-utils": "1.0.8",
+				"@walletconnect/jsonrpc-ws-connection": "^1.0.11",
+				"@walletconnect/keyvaluestorage": "^1.0.2",
+				"@walletconnect/logger": "^2.0.1",
+				"@walletconnect/relay-api": "^1.0.9",
+				"@walletconnect/relay-auth": "^1.0.4",
+				"@walletconnect/safe-json": "^1.0.2",
+				"@walletconnect/time": "^1.0.2",
+				"@walletconnect/types": "2.8.6",
+				"@walletconnect/utils": "2.8.6",
+				"events": "^3.3.0",
+				"lodash.isequal": "4.5.0",
+				"uint8arrays": "^3.1.0"
+			}
+		},
+		"@walletconnect/environment": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@walletconnect/environment/-/environment-1.0.1.tgz",
+			"integrity": "sha512-T426LLZtHj8e8rYnKfzsw1aG6+M0BT1ZxayMdv/p8yM0MU+eJDISqNY3/bccxRr4LrF9csq02Rhqt08Ibl0VRg==",
+			"requires": {
+				"tslib": "1.14.1"
+			},
+			"dependencies": {
+				"tslib": {
+					"version": "1.14.1",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+					"integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+				}
+			}
+		},
+		"@walletconnect/events": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@walletconnect/events/-/events-1.0.1.tgz",
+			"integrity": "sha512-NPTqaoi0oPBVNuLv7qPaJazmGHs5JGyO8eEAk5VGKmJzDR7AHzD4k6ilox5kxk1iwiOnFopBOOMLs86Oa76HpQ==",
+			"requires": {
+				"keyvaluestorage-interface": "^1.0.0",
+				"tslib": "1.14.1"
+			},
+			"dependencies": {
+				"tslib": {
+					"version": "1.14.1",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+					"integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+				}
+			}
+		},
+		"@walletconnect/heartbeat": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/@walletconnect/heartbeat/-/heartbeat-1.2.1.tgz",
+			"integrity": "sha512-yVzws616xsDLJxuG/28FqtZ5rzrTA4gUjdEMTbWB5Y8V1XHRmqq4efAxCw5ie7WjbXFSUyBHaWlMR+2/CpQC5Q==",
+			"requires": {
+				"@walletconnect/events": "^1.0.1",
+				"@walletconnect/time": "^1.0.2",
+				"tslib": "1.14.1"
+			},
+			"dependencies": {
+				"tslib": {
+					"version": "1.14.1",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+					"integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+				}
+			}
+		},
+		"@walletconnect/jsonrpc-provider": {
+			"version": "1.0.13",
+			"resolved": "https://registry.npmjs.org/@walletconnect/jsonrpc-provider/-/jsonrpc-provider-1.0.13.tgz",
+			"integrity": "sha512-K73EpThqHnSR26gOyNEL+acEex3P7VWZe6KE12ZwKzAt2H4e5gldZHbjsu2QR9cLeJ8AXuO7kEMOIcRv1QEc7g==",
+			"requires": {
+				"@walletconnect/jsonrpc-utils": "^1.0.8",
+				"@walletconnect/safe-json": "^1.0.2",
+				"tslib": "1.14.1"
+			},
+			"dependencies": {
+				"tslib": {
+					"version": "1.14.1",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+					"integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+				}
+			}
+		},
+		"@walletconnect/jsonrpc-types": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/@walletconnect/jsonrpc-types/-/jsonrpc-types-1.0.3.tgz",
+			"integrity": "sha512-iIQ8hboBl3o5ufmJ8cuduGad0CQm3ZlsHtujv9Eu16xq89q+BG7Nh5VLxxUgmtpnrePgFkTwXirCTkwJH1v+Yw==",
+			"requires": {
+				"keyvaluestorage-interface": "^1.0.0",
+				"tslib": "1.14.1"
+			},
+			"dependencies": {
+				"tslib": {
+					"version": "1.14.1",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+					"integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+				}
+			}
+		},
+		"@walletconnect/jsonrpc-utils": {
+			"version": "1.0.8",
+			"resolved": "https://registry.npmjs.org/@walletconnect/jsonrpc-utils/-/jsonrpc-utils-1.0.8.tgz",
+			"integrity": "sha512-vdeb03bD8VzJUL6ZtzRYsFMq1eZQcM3EAzT0a3st59dyLfJ0wq+tKMpmGH7HlB7waD858UWgfIcudbPFsbzVdw==",
+			"requires": {
+				"@walletconnect/environment": "^1.0.1",
+				"@walletconnect/jsonrpc-types": "^1.0.3",
+				"tslib": "1.14.1"
+			},
+			"dependencies": {
+				"tslib": {
+					"version": "1.14.1",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+					"integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+				}
+			}
+		},
+		"@walletconnect/jsonrpc-ws-connection": {
+			"version": "1.0.12",
+			"resolved": "https://registry.npmjs.org/@walletconnect/jsonrpc-ws-connection/-/jsonrpc-ws-connection-1.0.12.tgz",
+			"integrity": "sha512-HAcadga3Qjt1Cqy+qXEW6zjaCs8uJGdGQrqltzl3OjiK4epGZRdvSzTe63P+t/3z+D2wG+ffEPn0GVcDozmN1w==",
+			"requires": {
+				"@walletconnect/jsonrpc-utils": "^1.0.6",
+				"@walletconnect/safe-json": "^1.0.2",
+				"events": "^3.3.0",
+				"tslib": "1.14.1",
+				"ws": "^7.5.1"
+			},
+			"dependencies": {
+				"tslib": {
+					"version": "1.14.1",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+					"integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+				}
+			}
+		},
+		"@walletconnect/keyvaluestorage": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/@walletconnect/keyvaluestorage/-/keyvaluestorage-1.0.2.tgz",
+			"integrity": "sha512-U/nNG+VLWoPFdwwKx0oliT4ziKQCEoQ27L5Hhw8YOFGA2Po9A9pULUYNWhDgHkrb0gYDNt//X7wABcEWWBd3FQ==",
+			"requires": {
+				"safe-json-utils": "^1.1.1",
+				"tslib": "1.14.1"
+			},
+			"dependencies": {
+				"tslib": {
+					"version": "1.14.1",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+					"integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+				}
+			}
+		},
+		"@walletconnect/logger": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/@walletconnect/logger/-/logger-2.0.1.tgz",
+			"integrity": "sha512-SsTKdsgWm+oDTBeNE/zHxxr5eJfZmE9/5yp/Ku+zJtcTAjELb3DXueWkDXmE9h8uHIbJzIb5wj5lPdzyrjT6hQ==",
+			"requires": {
+				"pino": "7.11.0",
+				"tslib": "1.14.1"
+			},
+			"dependencies": {
+				"tslib": {
+					"version": "1.14.1",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+					"integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+				}
+			}
+		},
+		"@walletconnect/relay-api": {
+			"version": "1.0.9",
+			"resolved": "https://registry.npmjs.org/@walletconnect/relay-api/-/relay-api-1.0.9.tgz",
+			"integrity": "sha512-Q3+rylJOqRkO1D9Su0DPE3mmznbAalYapJ9qmzDgK28mYF9alcP3UwG/og5V7l7CFOqzCLi7B8BvcBUrpDj0Rg==",
+			"requires": {
+				"@walletconnect/jsonrpc-types": "^1.0.2",
+				"tslib": "1.14.1"
+			},
+			"dependencies": {
+				"tslib": {
+					"version": "1.14.1",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+					"integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+				}
+			}
+		},
+		"@walletconnect/relay-auth": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/@walletconnect/relay-auth/-/relay-auth-1.0.4.tgz",
+			"integrity": "sha512-kKJcS6+WxYq5kshpPaxGHdwf5y98ZwbfuS4EE/NkQzqrDFm5Cj+dP8LofzWvjrrLkZq7Afy7WrQMXdLy8Sx7HQ==",
+			"requires": {
+				"@stablelib/ed25519": "^1.0.2",
+				"@stablelib/random": "^1.0.1",
+				"@walletconnect/safe-json": "^1.0.1",
+				"@walletconnect/time": "^1.0.2",
+				"tslib": "1.14.1",
+				"uint8arrays": "^3.0.0"
+			},
+			"dependencies": {
+				"tslib": {
+					"version": "1.14.1",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+					"integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+				}
+			}
+		},
+		"@walletconnect/safe-json": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/@walletconnect/safe-json/-/safe-json-1.0.2.tgz",
+			"integrity": "sha512-Ogb7I27kZ3LPC3ibn8ldyUr5544t3/STow9+lzz7Sfo808YD7SBWk7SAsdBFlYgP2zDRy2hS3sKRcuSRM0OTmA==",
+			"requires": {
+				"tslib": "1.14.1"
+			},
+			"dependencies": {
+				"tslib": {
+					"version": "1.14.1",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+					"integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+				}
+			}
+		},
+		"@walletconnect/sign-client": {
+			"version": "2.8.6",
+			"resolved": "https://registry.npmjs.org/@walletconnect/sign-client/-/sign-client-2.8.6.tgz",
+			"integrity": "sha512-rOFTKTHP7oJfXgYHX7+SdB8VbcsEE3ZFG/bMdmZboWaBim1mrY3vUyDdKrNr0VgI3AwBiEQezQDfKxBX0pMSQQ==",
+			"requires": {
+				"@walletconnect/core": "2.8.6",
+				"@walletconnect/events": "^1.0.1",
+				"@walletconnect/heartbeat": "1.2.1",
+				"@walletconnect/jsonrpc-utils": "1.0.8",
+				"@walletconnect/logger": "^2.0.1",
+				"@walletconnect/time": "^1.0.2",
+				"@walletconnect/types": "2.8.6",
+				"@walletconnect/utils": "2.8.6",
+				"events": "^3.3.0"
+			}
+		},
+		"@walletconnect/time": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/@walletconnect/time/-/time-1.0.2.tgz",
+			"integrity": "sha512-uzdd9woDcJ1AaBZRhqy5rNC9laqWGErfc4dxA9a87mPdKOgWMD85mcFo9dIYIts/Jwocfwn07EC6EzclKubk/g==",
+			"requires": {
+				"tslib": "1.14.1"
+			},
+			"dependencies": {
+				"tslib": {
+					"version": "1.14.1",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+					"integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+				}
+			}
+		},
+		"@walletconnect/types": {
+			"version": "2.8.6",
+			"resolved": "https://registry.npmjs.org/@walletconnect/types/-/types-2.8.6.tgz",
+			"integrity": "sha512-Z/PFa3W1XdxeTcCtdR6lUsFgZfU/69wWJBPyclPwn7cu1+eriuCr6XZXQpJjib3flU+HnwHiXeUuqZaheehPxw==",
+			"requires": {
+				"@walletconnect/events": "^1.0.1",
+				"@walletconnect/heartbeat": "1.2.1",
+				"@walletconnect/jsonrpc-types": "1.0.3",
+				"@walletconnect/keyvaluestorage": "^1.0.2",
+				"@walletconnect/logger": "^2.0.1",
+				"events": "^3.3.0"
+			}
+		},
+		"@walletconnect/utils": {
+			"version": "2.8.6",
+			"resolved": "https://registry.npmjs.org/@walletconnect/utils/-/utils-2.8.6.tgz",
+			"integrity": "sha512-wcy6e5+COYo7tfNnW8YqidnATdJDIW6vDiWWE7A1F78Sl/VflkaevB9cIgyn8eLdxC1SxXgGoeC2oLP90nnHJg==",
+			"requires": {
+				"@stablelib/chacha20poly1305": "1.0.1",
+				"@stablelib/hkdf": "1.0.1",
+				"@stablelib/random": "^1.0.2",
+				"@stablelib/sha256": "1.0.1",
+				"@stablelib/x25519": "^1.0.3",
+				"@walletconnect/relay-api": "^1.0.9",
+				"@walletconnect/safe-json": "^1.0.2",
+				"@walletconnect/time": "^1.0.2",
+				"@walletconnect/types": "2.8.6",
+				"@walletconnect/window-getters": "^1.0.1",
+				"@walletconnect/window-metadata": "^1.0.1",
+				"detect-browser": "5.3.0",
+				"query-string": "7.1.3",
+				"uint8arrays": "^3.1.0"
+			}
+		},
+		"@walletconnect/window-getters": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@walletconnect/window-getters/-/window-getters-1.0.1.tgz",
+			"integrity": "sha512-vHp+HqzGxORPAN8gY03qnbTMnhqIwjeRJNOMOAzePRg4xVEEE2WvYsI9G2NMjOknA8hnuYbU3/hwLcKbjhc8+Q==",
+			"requires": {
+				"tslib": "1.14.1"
+			},
+			"dependencies": {
+				"tslib": {
+					"version": "1.14.1",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+					"integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+				}
+			}
+		},
+		"@walletconnect/window-metadata": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@walletconnect/window-metadata/-/window-metadata-1.0.1.tgz",
+			"integrity": "sha512-9koTqyGrM2cqFRW517BPY/iEtUDx2r1+Pwwu5m7sJ7ka79wi3EyqhqcICk/yDmv6jAS1rjKgTKXlEhanYjijcA==",
+			"requires": {
+				"@walletconnect/window-getters": "^1.0.1",
+				"tslib": "1.14.1"
+			},
+			"dependencies": {
+				"tslib": {
+					"version": "1.14.1",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+					"integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+				}
+			}
+		},
 		"acorn": {
 			"version": "8.9.0",
 			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.9.0.tgz",
-			"integrity": "sha512-jaVNAFBHNLXspO543WnNNPZFRtavh3skAkITqD0/2aeMkKZTN+254PyhwxFYrk3vQ1xfY+2wbesJMs/JC8/PwQ==",
-			"dev": true
+			"integrity": "sha512-jaVNAFBHNLXspO543WnNNPZFRtavh3skAkITqD0/2aeMkKZTN+254PyhwxFYrk3vQ1xfY+2wbesJMs/JC8/PwQ=="
 		},
 		"acorn-jsx": {
 			"version": "5.3.2",
@@ -3717,7 +6250,6 @@
 			"version": "5.3.0",
 			"resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
 			"integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
-			"dev": true,
 			"requires": {
 				"dequal": "^2.0.3"
 			}
@@ -3728,11 +6260,23 @@
 			"integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
 			"dev": true
 		},
+		"atomic-sleep": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/atomic-sleep/-/atomic-sleep-1.0.0.tgz",
+			"integrity": "sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ=="
+		},
+		"axios": {
+			"version": "0.24.0",
+			"resolved": "https://registry.npmjs.org/axios/-/axios-0.24.0.tgz",
+			"integrity": "sha512-Q6cWsys88HoPgAaFAVUb0WpPk0O8iTeisR9IMqy9G8AbO4NlpVknrnQS03zzF9PGAWgO3cgletO3VjV/P7VztA==",
+			"requires": {
+				"follow-redirects": "^1.14.4"
+			}
+		},
 		"axobject-query": {
 			"version": "3.2.1",
 			"resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-3.2.1.tgz",
 			"integrity": "sha512-jsyHu61e6N4Vbz/v18DHwWYKK0bSWLqn47eeDSKPB7m8tqMHF9YJ+mhIk2lVteyZrY8tnSj/jHOv4YiTCuCJgg==",
-			"dev": true,
 			"requires": {
 				"dequal": "^2.0.3"
 			}
@@ -3743,11 +6287,39 @@
 			"integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
 			"dev": true
 		},
+		"base-x": {
+			"version": "3.0.9",
+			"resolved": "https://registry.npmjs.org/base-x/-/base-x-3.0.9.tgz",
+			"integrity": "sha512-H7JU6iBHTal1gp56aKoaa//YUxEaAOUiydvrV/pILqIHXTtqxSkATOnDA2u+jZ/61sD+L/412+7kzXRtWukhpQ==",
+			"requires": {
+				"safe-buffer": "^5.0.1"
+			}
+		},
+		"base64-js": {
+			"version": "1.5.1",
+			"resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+			"integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
+		},
+		"bignumber.js": {
+			"version": "9.1.1",
+			"resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.1.1.tgz",
+			"integrity": "sha512-pHm4LsMJ6lzgNGVfZHjMoO8sdoRhOzOH4MLmY65Jg70bpxCKu5iOHNJyfF6OyvYw7t8Fpf35RuzUyqnQsj8Vig=="
+		},
 		"binary-extensions": {
 			"version": "2.2.0",
 			"resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
 			"integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==",
 			"dev": true
+		},
+		"blakejs": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/blakejs/-/blakejs-1.2.1.tgz",
+			"integrity": "sha512-QXUSXI3QVc/gJME0dBpXrag1kbzOqCjCX8/b54ntNyW6sjtoqxqRk3LTmXzaJoh71zMsDCjM+47jS7XiwN/+fQ=="
+		},
+		"bn.js": {
+			"version": "4.12.0",
+			"resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
+			"integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA=="
 		},
 		"brace-expansion": {
 			"version": "1.1.11",
@@ -3766,6 +6338,38 @@
 			"dev": true,
 			"requires": {
 				"fill-range": "^7.0.1"
+			}
+		},
+		"brorand": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz",
+			"integrity": "sha512-cKV8tMCEpQs4hK/ik71d6LrPOnpkpGBR0wzxqr68g2m/LB2GxVYQroAjMJZRVM1Y4BCjCKc3vAamxSzOY2RP+w=="
+		},
+		"bs58": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/bs58/-/bs58-4.0.1.tgz",
+			"integrity": "sha512-Ok3Wdf5vOIlBrgCvTq96gBkJw+JUEzdBgyaza5HLtPm7yTHkjRy8+JzNyHF7BHa0bNWOQIp3m5YF0nnFcOIKLw==",
+			"requires": {
+				"base-x": "^3.0.2"
+			}
+		},
+		"bs58check": {
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/bs58check/-/bs58check-2.1.2.tgz",
+			"integrity": "sha512-0TS1jicxdU09dwJMNZtVAfzPi6Q6QeN0pM1Fkzrjn+XYHvzMKPU3pHVpva+769iNVSfIYWf7LJ6WR+BuuMf8cA==",
+			"requires": {
+				"bs58": "^4.0.0",
+				"create-hash": "^1.1.0",
+				"safe-buffer": "^5.1.2"
+			}
+		},
+		"buffer": {
+			"version": "6.0.3",
+			"resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+			"integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+			"requires": {
+				"base64-js": "^1.3.1",
+				"ieee754": "^1.2.1"
 			}
 		},
 		"buffer-crc32": {
@@ -3826,11 +6430,19 @@
 				}
 			}
 		},
+		"cipher-base": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.4.tgz",
+			"integrity": "sha512-Kkht5ye6ZGmwv40uUDZztayT2ThLQGfnj/T71N/XzeZeo3nf8foyW7zGTsPYkEya3m5f3cAypH+qe7YOrM1U2Q==",
+			"requires": {
+				"inherits": "^2.0.1",
+				"safe-buffer": "^5.0.1"
+			}
+		},
 		"code-red": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/code-red/-/code-red-1.0.3.tgz",
 			"integrity": "sha512-kVwJELqiILQyG5aeuyKFbdsI1fmQy1Cmf7dQ8eGmVuJoaRVdwey7WaMknr2ZFeVSYSKT0rExsa8EGw0aoI/1QQ==",
-			"dev": true,
 			"requires": {
 				"@jridgewell/sourcemap-codec": "^1.4.14",
 				"@types/estree": "^1.0.0",
@@ -3866,6 +6478,18 @@
 			"integrity": "sha512-YZ3GUyn/o8gfKJlnlX7g7xq4gyO6OSuhGPKaaGssGB2qgDUS0gPgtTvoyZLTt9Ab6dC4hfc9dV5arkvc/OCmrw==",
 			"dev": true
 		},
+		"create-hash": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz",
+			"integrity": "sha512-z00bCGNHDG8mHAkP7CtT1qVu+bFQUPjYq/4Iv3C3kWjTFV10zIjfSoeqXo9Asws8gwSHDGj/hl2u4OGIjapeCg==",
+			"requires": {
+				"cipher-base": "^1.0.1",
+				"inherits": "^2.0.1",
+				"md5.js": "^1.3.4",
+				"ripemd160": "^2.0.1",
+				"sha.js": "^2.4.0"
+			}
+		},
 		"cross-spawn": {
 			"version": "7.0.3",
 			"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
@@ -3881,7 +6505,6 @@
 			"version": "2.3.1",
 			"resolved": "https://registry.npmjs.org/css-tree/-/css-tree-2.3.1.tgz",
 			"integrity": "sha512-6Fv1DV/TYw//QF5IzQdqsNDjx/wc8TrMBZsqjL9eW01tWb7R7k/mq+/VXfJCl7SoD5emsJop9cOByJZfs8hYIw==",
-			"dev": true,
 			"requires": {
 				"mdn-data": "2.0.30",
 				"source-map-js": "^1.0.1"
@@ -3893,6 +6516,11 @@
 			"integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==",
 			"dev": true
 		},
+		"csstype": {
+			"version": "3.1.2",
+			"resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.2.tgz",
+			"integrity": "sha512-I7K1Uu0MBPzaFKg4nI5Q7Vs2t+3gWWW648spaF+Rg7pI9ds18Ugn+lvg4SHczUdKlHI5LWBXyqfS8+DufyBsgQ=="
+		},
 		"debug": {
 			"version": "4.3.4",
 			"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
@@ -3901,6 +6529,11 @@
 			"requires": {
 				"ms": "2.1.2"
 			}
+		},
+		"decode-uri-component": {
+			"version": "0.2.2",
+			"resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.2.tgz",
+			"integrity": "sha512-FqUYQ+8o158GyGTrMFJms9qh3CqTKvAqgqsTnkLI8sKu0028orqBhxNMFkFen0zGyg6epACD32pjVk58ngIErQ=="
 		},
 		"deep-is": {
 			"version": "0.1.4",
@@ -3917,8 +6550,12 @@
 		"dequal": {
 			"version": "2.0.3",
 			"resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
-			"integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
-			"dev": true
+			"integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA=="
+		},
+		"detect-browser": {
+			"version": "5.3.0",
+			"resolved": "https://registry.npmjs.org/detect-browser/-/detect-browser-5.3.0.tgz",
+			"integrity": "sha512-53rsFbGdwMwlF7qvCt0ypLM5V5/Mbl0szB7GPN8y9NCcbknYOeVVXdrXEq+90IwAfrrzt6Hd+u2E2ntakICU8w=="
 		},
 		"detect-indent": {
 			"version": "6.1.0",
@@ -3950,6 +6587,39 @@
 				"esutils": "^2.0.2"
 			}
 		},
+		"duplexify": {
+			"version": "4.1.2",
+			"resolved": "https://registry.npmjs.org/duplexify/-/duplexify-4.1.2.tgz",
+			"integrity": "sha512-fz3OjcNCHmRP12MJoZMPglx8m4rrFP8rovnk4vT8Fs+aonZoCwGg10dSsQsfP/E62eZcPTMSMP6686fu9Qlqtw==",
+			"requires": {
+				"end-of-stream": "^1.4.1",
+				"inherits": "^2.0.3",
+				"readable-stream": "^3.1.1",
+				"stream-shift": "^1.0.0"
+			}
+		},
+		"elliptic": {
+			"version": "6.5.4",
+			"resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.4.tgz",
+			"integrity": "sha512-iLhC6ULemrljPZb+QutR5TQGB+pdW6KGD5RSegS+8sorOZT+rdQFbsQFJgvN3eRqNALqJer4oQ16YvJHlU8hzQ==",
+			"requires": {
+				"bn.js": "^4.11.9",
+				"brorand": "^1.1.0",
+				"hash.js": "^1.0.0",
+				"hmac-drbg": "^1.0.1",
+				"inherits": "^2.0.4",
+				"minimalistic-assert": "^1.0.1",
+				"minimalistic-crypto-utils": "^1.0.1"
+			}
+		},
+		"end-of-stream": {
+			"version": "1.4.4",
+			"resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
+			"integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
+			"requires": {
+				"once": "^1.4.0"
+			}
+		},
 		"es6-promise": {
 			"version": "3.3.1",
 			"resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-3.3.1.tgz",
@@ -3960,7 +6630,6 @@
 			"version": "0.17.19",
 			"resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.17.19.tgz",
 			"integrity": "sha512-XQ0jAPFkK/u3LcVRcvVHQcTIqD6E2H1fvZMA5dQPSOWb3suUbWbfbRf94pjc0bNzRYLfIrDRQXr7X+LHIm5oHw==",
-			"dev": true,
 			"requires": {
 				"@esbuild/android-arm": "0.17.19",
 				"@esbuild/android-arm64": "0.17.19",
@@ -4160,7 +6829,6 @@
 			"version": "3.0.3",
 			"resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
 			"integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
-			"dev": true,
 			"requires": {
 				"@types/estree": "^1.0.0"
 			}
@@ -4170,6 +6838,11 @@
 			"resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
 			"integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
 			"dev": true
+		},
+		"events": {
+			"version": "3.3.0",
+			"resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
+			"integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q=="
 		},
 		"fast-deep-equal": {
 			"version": "3.1.3",
@@ -4204,14 +6877,18 @@
 		"fast-json-stable-stringify": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
-			"integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
-			"dev": true
+			"integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="
 		},
 		"fast-levenshtein": {
 			"version": "2.0.6",
 			"resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
 			"integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
 			"dev": true
+		},
+		"fast-redact": {
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/fast-redact/-/fast-redact-3.2.0.tgz",
+			"integrity": "sha512-zaTadChr+NekyzallAMXATXLOR8MNx3zqpZ0MUF2aGf4EathnG0f32VLODNlY8IuGY3HoRO2L6/6fSzNsLaHIw=="
 		},
 		"fastq": {
 			"version": "1.15.0",
@@ -4240,6 +6917,11 @@
 				"to-regex-range": "^5.0.1"
 			}
 		},
+		"filter-obj": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/filter-obj/-/filter-obj-1.1.0.tgz",
+			"integrity": "sha512-8rXg1ZnX7xzy2NGDVkBVaAy+lSlPNwad13BtgSlLuxfIslyt5Vg64U7tFcCt4WS1R0hvtnQybT/IyCkGZ3DpXQ=="
+		},
 		"find-up": {
 			"version": "5.0.0",
 			"resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
@@ -4265,6 +6947,11 @@
 			"resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.7.tgz",
 			"integrity": "sha512-5nqDSxl8nn5BSNxyR3n4I6eDmbolI6WT+QqR547RwxQapgjQBmtktdP+HTBb/a/zLsbzERTONyUB5pefh5TtjQ==",
 			"dev": true
+		},
+		"follow-redirects": {
+			"version": "1.15.2",
+			"resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.2.tgz",
+			"integrity": "sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA=="
 		},
 		"fs.realpath": {
 			"version": "1.0.0",
@@ -4343,6 +7030,40 @@
 			"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
 			"dev": true
 		},
+		"hash-base": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/hash-base/-/hash-base-3.1.0.tgz",
+			"integrity": "sha512-1nmYp/rhMDiE7AYkDw+lLwlAzz0AntGIe51F3RfFfEqyQ3feY2eI/NcwC6umIQVOASPMsWJLJScWKSSvzL9IVA==",
+			"requires": {
+				"inherits": "^2.0.4",
+				"readable-stream": "^3.6.0",
+				"safe-buffer": "^5.2.0"
+			}
+		},
+		"hash.js": {
+			"version": "1.1.7",
+			"resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.7.tgz",
+			"integrity": "sha512-taOaskGt4z4SOANNseOviYDvjEJinIkRgmp7LbKP2YTTmVxWBl87s/uzK9r+44BclBSp2X7K1hqeNfz9JbBeXA==",
+			"requires": {
+				"inherits": "^2.0.3",
+				"minimalistic-assert": "^1.0.1"
+			}
+		},
+		"hmac-drbg": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
+			"integrity": "sha512-Tti3gMqLdZfhOQY1Mzf/AanLiqh1WTiJgEj26ZuYQ9fbkLomzGchCws4FyrSd4VkpBfiNhaE1On+lOz894jvXg==",
+			"requires": {
+				"hash.js": "^1.0.3",
+				"minimalistic-assert": "^1.0.0",
+				"minimalistic-crypto-utils": "^1.0.1"
+			}
+		},
+		"ieee754": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+			"integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA=="
+		},
 		"ignore": {
 			"version": "5.2.4",
 			"resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.4.tgz",
@@ -4384,8 +7105,7 @@
 		"inherits": {
 			"version": "2.0.4",
 			"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-			"integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-			"dev": true
+			"integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
 		},
 		"is-binary-path": {
 			"version": "2.1.0",
@@ -4427,7 +7147,6 @@
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/is-reference/-/is-reference-3.0.1.tgz",
 			"integrity": "sha512-baJJdQLiYaJdvFbJqXrcGv3WU3QCzBlUcI5QhbesIm6/xPsvmO+2CDoi/GMOFBQEQm+PXkwOPrp9KK5ozZsp2w==",
-			"dev": true,
 			"requires": {
 				"@types/estree": "*"
 			}
@@ -4458,6 +7177,11 @@
 			"resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
 			"integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
 			"dev": true
+		},
+		"keyvaluestorage-interface": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/keyvaluestorage-interface/-/keyvaluestorage-interface-1.0.0.tgz",
+			"integrity": "sha512-8t6Q3TclQ4uZynJY9IGr2+SsIGwK9JHcO6ootkHCGA0CrQCRy+VkouYNO2xicET6b9al7QKzpebNow+gkpCL8g=="
 		},
 		"kleur": {
 			"version": "4.1.5",
@@ -4490,8 +7214,7 @@
 		"locate-character": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/locate-character/-/locate-character-3.0.0.tgz",
-			"integrity": "sha512-SW13ws7BjaeJ6p7Q6CO2nchbYEc3X3J6WrmTTDto7yMPqVSZTUyY5Tjbid+Ab8gLnATtygYtiDIJGQRRn2ZOiA==",
-			"dev": true
+			"integrity": "sha512-SW13ws7BjaeJ6p7Q6CO2nchbYEc3X3J6WrmTTDto7yMPqVSZTUyY5Tjbid+Ab8gLnATtygYtiDIJGQRRn2ZOiA=="
 		},
 		"locate-path": {
 			"version": "6.0.0",
@@ -4501,6 +7224,11 @@
 			"requires": {
 				"p-locate": "^5.0.0"
 			}
+		},
+		"lodash.isequal": {
+			"version": "4.5.0",
+			"resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
+			"integrity": "sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ=="
 		},
 		"lodash.merge": {
 			"version": "4.6.2",
@@ -4521,16 +7249,24 @@
 			"version": "0.30.0",
 			"resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.0.tgz",
 			"integrity": "sha512-LA+31JYDJLs82r2ScLrlz1GjSgu66ZV518eyWT+S8VhyQn/JL0u9MeBOvQMGYiPk1DBiSN9DDMOcXvigJZaViQ==",
-			"dev": true,
 			"requires": {
 				"@jridgewell/sourcemap-codec": "^1.4.13"
+			}
+		},
+		"md5.js": {
+			"version": "1.3.5",
+			"resolved": "https://registry.npmjs.org/md5.js/-/md5.js-1.3.5.tgz",
+			"integrity": "sha512-xitP+WxNPcTTOgnTJcrhM0xvdPepipPSf3I8EIpGKeFLjt3PlJLIDG3u8EX53ZIubkb+5U2+3rELYpEhHhzdkg==",
+			"requires": {
+				"hash-base": "^3.0.0",
+				"inherits": "^2.0.1",
+				"safe-buffer": "^5.1.2"
 			}
 		},
 		"mdn-data": {
 			"version": "2.0.30",
 			"resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.30.tgz",
-			"integrity": "sha512-GaqWWShW4kv/G9IEucWScBx9G1/vsFZZJUO+tD26M8J8z3Kw5RDQjaoZe03YAClgeS/SWPOcb4nkFBTEi5DUEA==",
-			"dev": true
+			"integrity": "sha512-GaqWWShW4kv/G9IEucWScBx9G1/vsFZZJUO+tD26M8J8z3Kw5RDQjaoZe03YAClgeS/SWPOcb4nkFBTEi5DUEA=="
 		},
 		"merge2": {
 			"version": "1.4.1",
@@ -4559,6 +7295,16 @@
 			"resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
 			"integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==",
 			"dev": true
+		},
+		"minimalistic-assert": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
+			"integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A=="
+		},
+		"minimalistic-crypto-utils": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz",
+			"integrity": "sha512-JIYlbt6g8i5jKfJ3xz7rF0LXmv2TkDxBLUkiBeZ7bAx4GnnNMr8xFpGnOxn6GhTEHx3SjRrZEoU+j04prX1ktg=="
 		},
 		"minimatch": {
 			"version": "3.1.2",
@@ -4602,6 +7348,11 @@
 			"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
 			"dev": true
 		},
+		"multiformats": {
+			"version": "9.9.0",
+			"resolved": "https://registry.npmjs.org/multiformats/-/multiformats-9.9.0.tgz",
+			"integrity": "sha512-HoMUjhH9T8DDBNT+6xzkrd9ga/XiBI4xLr58LJACwK6G3HTOPeMz4nB4KJs33L2BelrIJa7P0VuNaVF3hMYfjg=="
+		},
 		"nanoid": {
 			"version": "3.3.6",
 			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.6.tgz",
@@ -4626,11 +7377,15 @@
 			"integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
 			"dev": true
 		},
+		"on-exit-leak-free": {
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/on-exit-leak-free/-/on-exit-leak-free-0.2.0.tgz",
+			"integrity": "sha512-dqaz3u44QbRXQooZLTUKU41ZrzYrcvLISVgbrzbyCMxpmSLJvZ3ZamIJIZ29P6OhZIkNIQKosdeM6t1LYbA9hg=="
+		},
 		"once": {
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
 			"integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
-			"dev": true,
 			"requires": {
 				"wrappy": "1"
 			}
@@ -4704,7 +7459,6 @@
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/periscopic/-/periscopic-3.1.0.tgz",
 			"integrity": "sha512-vKiQ8RRtkl9P+r/+oefh25C3fhybptkHKCZSPlcXiJux2tJF55GnEj3BVn4A5gKfq9NWWXXrxkHBwVPUfH0opw==",
-			"dev": true,
 			"requires": {
 				"@types/estree": "^1.0.0",
 				"estree-walker": "^3.0.0",
@@ -4722,6 +7476,38 @@
 			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
 			"integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
 			"dev": true
+		},
+		"pino": {
+			"version": "7.11.0",
+			"resolved": "https://registry.npmjs.org/pino/-/pino-7.11.0.tgz",
+			"integrity": "sha512-dMACeu63HtRLmCG8VKdy4cShCPKaYDR4youZqoSWLxl5Gu99HUw8bw75thbPv9Nip+H+QYX8o3ZJbTdVZZ2TVg==",
+			"requires": {
+				"atomic-sleep": "^1.0.0",
+				"fast-redact": "^3.0.0",
+				"on-exit-leak-free": "^0.2.0",
+				"pino-abstract-transport": "v0.5.0",
+				"pino-std-serializers": "^4.0.0",
+				"process-warning": "^1.0.0",
+				"quick-format-unescaped": "^4.0.3",
+				"real-require": "^0.1.0",
+				"safe-stable-stringify": "^2.1.0",
+				"sonic-boom": "^2.2.1",
+				"thread-stream": "^0.15.1"
+			}
+		},
+		"pino-abstract-transport": {
+			"version": "0.5.0",
+			"resolved": "https://registry.npmjs.org/pino-abstract-transport/-/pino-abstract-transport-0.5.0.tgz",
+			"integrity": "sha512-+KAgmVeqXYbTtU2FScx1XS3kNyfZ5TrXY07V96QnUSFqo2gAqlvmaxH67Lj7SWazqsMabf+58ctdTcBgnOLUOQ==",
+			"requires": {
+				"duplexify": "^4.1.2",
+				"split2": "^4.0.0"
+			}
+		},
+		"pino-std-serializers": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-4.0.0.tgz",
+			"integrity": "sha512-cK0pekc1Kjy5w9V2/n+8MkZwusa6EyyxfeQCB799CQRhRt/CqYKiWs5adeu8Shve2ZNffvfC/7J64A2PJo1W/Q=="
 		},
 		"postcss": {
 			"version": "8.4.24",
@@ -4787,17 +7573,53 @@
 			"dev": true,
 			"requires": {}
 		},
+		"process-warning": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/process-warning/-/process-warning-1.0.0.tgz",
+			"integrity": "sha512-du4wfLyj4yCZq1VupnVSZmRsPJsNuxoDQFdCFHLaYiEbFBD7QE0a+I4D7hOxrVnh78QE/YipFAj9lXHiXocV+Q=="
+		},
 		"punycode": {
 			"version": "2.3.0",
 			"resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.0.tgz",
 			"integrity": "sha512-rRV+zQD8tVFys26lAGR9WUuS4iUAngJScM+ZRSKtvl5tKeZ2t5bvdNFdNHBW9FWR4guGHlgmsZ1G7BSm2wTbuA==",
 			"dev": true
 		},
+		"qrcode-svg": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/qrcode-svg/-/qrcode-svg-1.1.0.tgz",
+			"integrity": "sha512-XyQCIXux1zEIA3NPb0AeR8UMYvXZzWEhgdBgBjH9gO7M48H9uoHzviNz8pXw3UzrAcxRRRn9gxHewAVK7bn9qw=="
+		},
+		"query-string": {
+			"version": "7.1.3",
+			"resolved": "https://registry.npmjs.org/query-string/-/query-string-7.1.3.tgz",
+			"integrity": "sha512-hh2WYhq4fi8+b+/2Kg9CEge4fDPvHS534aOOvOZeQ3+Vf2mCFsaFBYj0i+iXcAq6I9Vzp5fjMFBlONvayDC1qg==",
+			"requires": {
+				"decode-uri-component": "^0.2.2",
+				"filter-obj": "^1.1.0",
+				"split-on-first": "^1.0.0",
+				"strict-uri-encode": "^2.0.0"
+			}
+		},
 		"queue-microtask": {
 			"version": "1.2.3",
 			"resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
 			"integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
 			"dev": true
+		},
+		"quick-format-unescaped": {
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/quick-format-unescaped/-/quick-format-unescaped-4.0.4.tgz",
+			"integrity": "sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg=="
+		},
+		"readable-stream": {
+			"version": "3.6.2",
+			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+			"integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+			"requires": {
+				"inherits": "^2.0.3",
+				"string_decoder": "^1.1.1",
+				"util-deprecate": "^1.0.1"
+			}
 		},
 		"readdirp": {
 			"version": "3.6.0",
@@ -4807,6 +7629,11 @@
 			"requires": {
 				"picomatch": "^2.2.1"
 			}
+		},
+		"real-require": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/real-require/-/real-require-0.1.0.tgz",
+			"integrity": "sha512-r/H9MzAWtrv8aSVjPCMFpDMl5q66GqtmmRkRjpHTsp4zBAa+snZyiQNlMONiUmEJcsnaw0wCauJ2GWODr/aFkg=="
 		},
 		"resolve-from": {
 			"version": "4.0.0",
@@ -4829,6 +7656,15 @@
 				"glob": "^7.1.3"
 			}
 		},
+		"ripemd160": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-2.0.2.tgz",
+			"integrity": "sha512-ii4iagi25WusVoiC4B4lq7pbXfAp3D9v5CwfkY33vffw2+pkDjY1D8GaN7spsxvCSx8dkPqOZCEZyfxcmJG2IA==",
+			"requires": {
+				"hash-base": "^3.0.0",
+				"inherits": "^2.0.1"
+			}
+		},
 		"rollup": {
 			"version": "3.26.0",
 			"resolved": "https://registry.npmjs.org/rollup/-/rollup-3.26.0.tgz",
@@ -4847,6 +7683,21 @@
 				"queue-microtask": "^1.2.2"
 			}
 		},
+		"rxjs": {
+			"version": "6.6.7",
+			"resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.6.7.tgz",
+			"integrity": "sha512-hTdwr+7yYNIT5n4AMYp85KA6yw2Va0FLa3Rguvbpa4W3I5xynaBZo41cM3XM+4Q6fRMj3sBYIR1VAmZMXYJvRQ==",
+			"requires": {
+				"tslib": "^1.9.0"
+			},
+			"dependencies": {
+				"tslib": {
+					"version": "1.14.1",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+					"integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+				}
+			}
+		},
 		"sade": {
 			"version": "1.8.1",
 			"resolved": "https://registry.npmjs.org/sade/-/sade-1.8.1.tgz",
@@ -4855,6 +7706,21 @@
 			"requires": {
 				"mri": "^1.1.0"
 			}
+		},
+		"safe-buffer": {
+			"version": "5.2.1",
+			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+			"integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
+		},
+		"safe-json-utils": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/safe-json-utils/-/safe-json-utils-1.1.1.tgz",
+			"integrity": "sha512-SAJWGKDs50tAbiDXLf89PDwt9XYkWyANFWVzn4dTXl5QyI8t2o/bW5/OJl3lvc2WVU4MEpTo9Yz5NVFNsp+OJQ=="
+		},
+		"safe-stable-stringify": {
+			"version": "2.4.3",
+			"resolved": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-2.4.3.tgz",
+			"integrity": "sha512-e2bDA2WJT0wxseVd4lsDP4+3ONX6HpMXQa1ZhFQ7SU+GjvORCmShbCMltrtIDfkYhVHrOcPtj+KhmDBdPdZD1g=="
 		},
 		"sander": {
 			"version": "0.5.1",
@@ -4888,11 +7754,25 @@
 				"lru-cache": "^6.0.0"
 			}
 		},
+		"seroval": {
+			"version": "0.5.1",
+			"resolved": "https://registry.npmjs.org/seroval/-/seroval-0.5.1.tgz",
+			"integrity": "sha512-ZfhQVB59hmIauJG5Ydynupy8KHyr5imGNtdDhbZG68Ufh1Ynkv9KOYOAABf71oVbQxJ8VkWnMHAjEHE7fWkH5g=="
+		},
 		"set-cookie-parser": {
 			"version": "2.6.0",
 			"resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.6.0.tgz",
 			"integrity": "sha512-RVnVQxTXuerk653XfuliOxBP81Sf0+qfQE73LIYKcyMYHG94AuH0kgrQpRDuTZnSmjpysHmzxJXKNfa6PjFhyQ==",
 			"dev": true
+		},
+		"sha.js": {
+			"version": "2.4.11",
+			"resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
+			"integrity": "sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==",
+			"requires": {
+				"inherits": "^2.0.1",
+				"safe-buffer": "^5.0.1"
+			}
 		},
 		"shebang-command": {
 			"version": "2.0.0",
@@ -4926,6 +7806,23 @@
 			"integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
 			"dev": true
 		},
+		"solid-js": {
+			"version": "1.7.7",
+			"resolved": "https://registry.npmjs.org/solid-js/-/solid-js-1.7.7.tgz",
+			"integrity": "sha512-SPdYVke/Z6Za24PBTbULyQYPrhGO1ZbPany76atO2zF2dmYn2pCotbsw1JtlgWnr9dK2JbwPGnA3ODTGPLhZNw==",
+			"requires": {
+				"csstype": "^3.1.0",
+				"seroval": "^0.5.0"
+			}
+		},
+		"sonic-boom": {
+			"version": "2.8.0",
+			"resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-2.8.0.tgz",
+			"integrity": "sha512-kuonw1YOYYNOve5iHdSahXPOK49GqwA+LZhI6Wz/l0rP57iKyXXIHaRagOBHAPmGwJC6od2Z9zgvZ5loSgMlVg==",
+			"requires": {
+				"atomic-sleep": "^1.0.0"
+			}
+		},
 		"sorcery": {
 			"version": "0.11.0",
 			"resolved": "https://registry.npmjs.org/sorcery/-/sorcery-0.11.0.tgz",
@@ -4941,14 +7838,41 @@
 		"source-map-js": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.0.2.tgz",
-			"integrity": "sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==",
-			"dev": true
+			"integrity": "sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw=="
+		},
+		"split-on-first": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/split-on-first/-/split-on-first-1.1.0.tgz",
+			"integrity": "sha512-43ZssAJaMusuKWL8sKUBQXHWOpq8d6CfN/u1p4gUzfJkM05C8rxTmYrkIPTXapZpORA6LkkzcUulJ8FqA7Uudw=="
+		},
+		"split2": {
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
+			"integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg=="
+		},
+		"stream-shift": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.1.tgz",
+			"integrity": "sha512-AiisoFqQ0vbGcZgQPY1cdP2I76glaVA/RauYR4G4thNFgkTqr90yXTo4LYX60Jl+sIlPNHHdGSwo01AvbKUSVQ=="
 		},
 		"streamsearch": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-1.1.0.tgz",
 			"integrity": "sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==",
 			"dev": true
+		},
+		"strict-uri-encode": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-2.0.0.tgz",
+			"integrity": "sha512-QwiXZgpRcKkhTj2Scnn++4PKtWsH0kpzZ62L2R6c/LUVYv7hVnZqcg2+sMuT6R7Jusu1vviK/MFsu6kNJfWlEQ=="
+		},
+		"string_decoder": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+			"integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+			"requires": {
+				"safe-buffer": "~5.2.0"
+			}
 		},
 		"strip-ansi": {
 			"version": "6.0.1",
@@ -4987,7 +7911,6 @@
 			"version": "4.0.3",
 			"resolved": "https://registry.npmjs.org/svelte/-/svelte-4.0.3.tgz",
 			"integrity": "sha512-SSJZBR+Uca3Xa/R18/7IkkifDdz2Jfuq2eXMUphDhabDxQL6qR8QAUoEmrtYWhzeV0civoFw4Dcvo2yscysdeg==",
-			"dev": true,
 			"requires": {
 				"@ampproject/remapping": "^2.2.1",
 				"@jridgewell/sourcemap-codec": "^1.4.15",
@@ -5082,11 +8005,31 @@
 				}
 			}
 		},
+		"svelte-tezos": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/svelte-tezos/-/svelte-tezos-1.0.0.tgz",
+			"integrity": "sha512-3hFXywpHgCplSl397VjnjUQY0CjWVIlT18sMoErscKgTlgLDZ4V7xu96y1PubhyRxC9S0dyMOIzQar2U4Gki6Q==",
+			"requires": {
+				"@airgap/beacon-sdk": "^4.0.4",
+				"@esbuild-plugins/node-globals-polyfill": "^0.2.3",
+				"@taquito/beacon-wallet": "^17.0.0",
+				"@taquito/taquito": "^17.0.0",
+				"vite-compatible-readable-stream": "^3.6.1"
+			}
+		},
 		"text-table": {
 			"version": "0.2.0",
 			"resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
 			"integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
 			"dev": true
+		},
+		"thread-stream": {
+			"version": "0.15.2",
+			"resolved": "https://registry.npmjs.org/thread-stream/-/thread-stream-0.15.2.tgz",
+			"integrity": "sha512-UkEhKIg2pD+fjkHQKyJO3yoIvAP3N6RlNFt2dUhcS1FGvCD1cQa1M/PGknCLFIyZdtJOWQjejp7bdNqmN7zwdA==",
+			"requires": {
+				"real-require": "^0.1.0"
+			}
 		},
 		"to-regex-range": {
 			"version": "5.0.1",
@@ -5141,11 +8084,24 @@
 			"integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
 			"dev": true
 		},
+		"typedarray-to-buffer": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/typedarray-to-buffer/-/typedarray-to-buffer-4.0.0.tgz",
+			"integrity": "sha512-6dOYeZfS3O9RtRD1caom0sMxgK59b27+IwoNy8RDPsmslSGOyU+mpTamlaIW7aNKi90ZQZ9DFaZL3YRoiSCULQ=="
+		},
 		"typescript": {
 			"version": "5.1.6",
 			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.1.6.tgz",
 			"integrity": "sha512-zaWCozRZ6DLEWAWFrVDz1H6FVXzUSfTy5FUMWsQlU8Ym5JP9eO4xkTIROFCQvhQf61z6O/G6ugw3SgAnvvm+HA==",
 			"dev": true
+		},
+		"uint8arrays": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-3.1.1.tgz",
+			"integrity": "sha512-+QJa8QRnbdXVpHYjLoTpJIdCTiw9Ir62nocClWuXIq2JIh4Uta0cQsTSpFL678p2CN8B+XSApwcU+pQEqVpKWg==",
+			"requires": {
+				"multiformats": "^9.4.2"
+			}
 		},
 		"undici": {
 			"version": "5.22.1",
@@ -5168,8 +8124,7 @@
 		"util-deprecate": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-			"integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
-			"dev": true
+			"integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
 		},
 		"vite": {
 			"version": "4.3.9",
@@ -5181,6 +8136,16 @@
 				"fsevents": "~2.3.2",
 				"postcss": "^8.4.23",
 				"rollup": "^3.21.0"
+			}
+		},
+		"vite-compatible-readable-stream": {
+			"version": "3.6.1",
+			"resolved": "https://registry.npmjs.org/vite-compatible-readable-stream/-/vite-compatible-readable-stream-3.6.1.tgz",
+			"integrity": "sha512-t20zYkrSf868+j/p31cRIGN28Phrjm3nRSLR2fyc2tiWi4cZGVdv68yNlwnIINTkMTmPoMiSlc0OadaO7DXZaQ==",
+			"requires": {
+				"inherits": "^2.0.3",
+				"string_decoder": "^1.1.1",
+				"util-deprecate": "^1.0.1"
 			}
 		},
 		"vitefu": {
@@ -5202,8 +8167,13 @@
 		"wrappy": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-			"integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
-			"dev": true
+			"integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="
+		},
+		"ws": {
+			"version": "7.5.9",
+			"resolved": "https://registry.npmjs.org/ws/-/ws-7.5.9.tgz",
+			"integrity": "sha512-F+P9Jil7UiSKSkppIiD94dN07AwvFixvLIj1Og1Rl9GGMuNipJnV9JzjD6XuqmAeiswGvUmNLjr5cFuXwNS77Q==",
+			"requires": {}
 		},
 		"yallist": {
 			"version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -27,5 +27,11 @@
 		"typescript": "^5.0.0",
 		"vite": "^4.3.6"
 	},
-	"type": "module"
+	"type": "module",
+	"dependencies": {
+		"@esbuild-plugins/node-globals-polyfill": "^0.2.3",
+		"buffer": "^6.0.3",
+		"svelte-tezos": "^1.0.0",
+		"vite-compatible-readable-stream": "^3.6.1"
+	}
 }

--- a/src/app.html
+++ b/src/app.html
@@ -4,6 +4,9 @@
 		<meta charset="utf-8" />
 		<link rel="icon" href="%sveltekit.assets%/favicon.png" />
 		<meta name="viewport" content="width=device-width" />
+		<script>
+      const global = globalThis;
+    </script>
 		%sveltekit.head%
 	</head>
 	<body data-sveltekit-preload-data="hover">

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -1,0 +1,6 @@
+<script>
+	import { Buffer } from 'buffer';
+	global.Buffer = Buffer;
+</script>
+
+<slot />

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -1,2 +1,52 @@
-<h1>Welcome to SvelteKit</h1>
-<p>Visit <a href="https://kit.svelte.dev">kit.svelte.dev</a> to read the documentation</p>
+<script lang="ts">
+	import { onMount } from "svelte";
+	import {
+		createStore, 
+		userAddress, 
+		connected, 
+		blockHead,
+		connect,
+		disconnect
+	} from "svelte-tezos";
+	import type { NetworkType } from "@airgap/beacon-sdk";
+
+	onMount(async () => {
+		createStore({ 
+			rpcUrl: 'https://mainnet.api.tez.ie', 
+			dappName: 'svelte-tezos-test', 
+			networkType: "mainnet" as NetworkType,
+		});
+
+		await connect();
+	});
+
+	let blocks: Array<typeof $blockHead> = [];
+
+	$: console.log({ blocks, $blockHead });
+	$: if($blockHead) blocks = [...blocks, $blockHead];
+</script>
+
+<div style="display: flex; align-items: center;">
+	<p>{$connected} - {$userAddress}</p>
+
+	{#if $connected}
+		<button on:click={disconnect}>
+			Disconnect
+		</button>
+	{:else}
+		<button on:click={connect}>
+			Connect
+		</button>
+	{/if}
+</div>
+
+<h1>Latest blocks from the Tezos blockchain</h1>
+
+{#each blocks as block}
+	{#if block}
+		<div>
+			<h2>Block {block.level}</h2>
+			<p>Timestamp: {block.lastUpdate}</p>
+		</div>
+	{/if}
+{/each}

--- a/src/routes/+page.ts
+++ b/src/routes/+page.ts
@@ -1,0 +1,1 @@
+export const ssr = false;

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,6 +1,32 @@
-import { sveltekit } from '@sveltejs/kit/vite';
-import { defineConfig } from 'vite';
+import { defineConfig } from "vite";
+import { sveltekit } from "@sveltejs/kit/vite";
+import { NodeGlobalsPolyfillPlugin } from '@esbuild-plugins/node-globals-polyfill';
 
 export default defineConfig({
-	plugins: [sveltekit()]
+	plugins: [sveltekit()],
+	server: {
+		port: 5173
+	},
+	resolve: {
+		alias: {
+			"readable-stream": "vite-compatible-readable-stream",
+			stream: "vite-compatible-readable-stream"
+		}
+	},
+	optimizeDeps: {
+		esbuildOptions: {
+			plugins: [
+				NodeGlobalsPolyfillPlugin({
+					process: true,
+					buffer: true
+				})
+			]
+		},
+	},
+	build: {
+		target: "esnext",
+		commonjsOptions: {
+			transformMixedEsModules: true,
+		},
+	},
 });


### PR DESCRIPTION
# basic dapp example with svelte-tezos

feature list:
1. sets up vite to properly with both `taquito` and `beacon` packages.
2. references the [`svelte-tezos`](https://www.npmjs.com/package/svelte-tezos) library for easy access to svelte store to interact with tezos.
3. shows latest blocks from tezos mainnet
4. allows you to connect/disconnect a wallet using beacon.